### PR TITLE
chore: modernize license metadata for packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,9 @@ description = "OData filter and projection helpers for AWS DynamoDB"
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [{ name = "Robert Smith", email = "robert@rsmith.us" }]
-license = { text = "MIT" }
+license = "MIT"
 keywords = ["dynamodb", "odata", "boto3", "aws", "projection", "filter"]
 classifiers = [
-  "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/src/dynamo_odata.egg-info/PKG-INFO
+++ b/src/dynamo_odata.egg-info/PKG-INFO
@@ -3,13 +3,12 @@ Name: dynamo-odata
 Version: 0.1.0
 Summary: OData filter and projection helpers for AWS DynamoDB
 Author-email: Robert Smith <robert@rsmith.us>
-License: MIT
+License-Expression: MIT
 Project-URL: Homepage, https://github.com/smitrob/dynamo-odata
 Project-URL: Repository, https://github.com/smitrob/dynamo-odata
 Project-URL: Issues, https://github.com/smitrob/dynamo-odata/issues
 Project-URL: Changelog, https://github.com/smitrob/dynamo-odata/blob/main/CHANGELOG.md
 Keywords: dynamodb,odata,boto3,aws,projection,filter
-Classifier: License :: OSI Approved :: MIT License
 Classifier: Programming Language :: Python :: 3
 Classifier: Programming Language :: Python :: 3.10
 Classifier: Programming Language :: Python :: 3.11
@@ -31,8 +30,6 @@ Provides-Extra: dev
 Requires-Dist: pytest>=8.0; extra == "dev"
 Requires-Dist: pytest-asyncio>=0.23; extra == "dev"
 Requires-Dist: ruff>=0.6; extra == "dev"
-Requires-Dist: pre-commit>=3.7; extra == "dev"
-Requires-Dist: mypy>=1.11; extra == "dev"
 Dynamic: license-file
 
 # dynamo-odata
@@ -326,9 +323,9 @@ deleted_items = db.get_all(
 ```python
 db = DynamoDb(
     table_name="users",           # Required
-    region="us-west-2",           # Optional, defaults to us-west-2
-    pk_separator="::",            # Optional, default partition key separator
-    sk_separator="#",             # Optional, default sort key status separator
+    region="us-west-2",           # Optional, defaults to AWS_DEFAULT_REGION
+    active_prefix="1#",           # Optional, for single-table pattern
+    inactive_prefix="0#",         # Optional
 )
 ```
 
@@ -351,16 +348,6 @@ db = DynamoDb(
 |----------|------|---------|-------|
 | `build_filter(expr)` | OData filter string | ConditionBase | Parse filter expression |
 | `build_projection(fields)` | list[str] | (expr, attr_names_dict) | Build projection + name map |
-
-**Key Helpers (DynamoDb methods):**
-
-| Method | Args | Returns | Notes |
-|--------|------|---------|-------|
-| `build_pk` | `*parts` | str | Joins key parts with `pk_separator` |
-| `build_active_sk` | `value` | str | Ensures active SK prefix (`1#` by default) |
-| `build_inactive_sk` | `value` | str | Ensures inactive SK prefix (`0#` by default) |
-| `is_active_sk` | `value` | bool | Checks active prefix |
-| `is_inactive_sk` | `value` | bool | Checks inactive prefix |
 
 ---
 

--- a/src/dynamo_odata.egg-info/SOURCES.txt
+++ b/src/dynamo_odata.egg-info/SOURCES.txt
@@ -32,7 +32,6 @@ tests/test_build_filter.py
 tests/test_delete.py
 tests/test_get.py
 tests/test_get_all.py
-tests/test_key_helpers.py
 tests/test_odata_dynamo.py
 tests/test_projection.py
 tests/test_public_api.py


### PR DESCRIPTION
## Summary
- switch project license metadata to SPDX string format
- remove deprecated license classifier
- refresh generated egg-info metadata

## Validation
- python -m build
- python -m twine check dist/*
- no setuptools deprecation warnings in build log