### PR TITLE
feat: add regulated profile policy primitives and guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,6 +6,8 @@ body:
     attributes:
       value: |
         Thanks for reporting a bug.
+        Please keep this issue vendor-neutral. Avoid product/customer names and
+        internal project-specific data unless it is strictly required.
   - type: input
     id: summary
     attributes:
@@ -40,3 +42,12 @@ body:
     attributes:
       label: Package version
       placeholder: 0.1.0
+  - type: checkboxes
+    id: neutrality
+    attributes:
+      label: Open-source neutrality
+      options:
+        - label: I removed product/customer/internal project names unless required
+          required: true
+        - label: I used generic examples and no project-specific datasets/identifiers
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,11 @@ name: Feature request
 description: Propose an improvement
 labels: [enhancement]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Please keep this issue vendor-neutral. Avoid product/customer names and
+        internal project-specific data unless it is strictly required.
   - type: input
     id: summary
     attributes:
@@ -26,3 +31,12 @@ body:
     id: alternatives
     attributes:
       label: Alternatives considered
+  - type: checkboxes
+    id: neutrality
+    attributes:
+      label: Open-source neutrality
+      options:
+        - label: I removed product/customer/internal project names unless required
+          required: true
+        - label: I used generic examples and no project-specific datasets/identifiers
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,3 +24,5 @@ Describe what changed and why.
 - [ ] I followed the repo style and conventions
 - [ ] I updated docs as needed
 - [ ] I verified no sensitive data/secrets are included
+- [ ] I kept this PR vendor-neutral (no product/customer/internal project names unless required)
+- [ ] I removed project-specific datasets/identifiers and used generic examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Configurable key schema support:
+  - `KeySchema` for custom key attribute names and separators
+  - `DEFAULT_KEY_SCHEMA` and `UPPERCASE_KEY_SCHEMA` presets
+  - `DynamoDb` support for `key_schema`, with backward-compatible defaults
+- Optional API guardrails:
+  - `PartitionKeyGuard` and `PartitionKeyValidationError`
+  - `FilterPolicy` and `FilterPolicyViolationError`
+  - `validate_filter()` helper for policy-only validation
+- Optional regulated profile helpers:
+  - `RegulatedProfile` and `build_regulated_profile()`
+  - `validate_regulated_query()` for combined guard validation
+  - `validate_page_size()` for bounded pagination
+  - `apply_response_field_policy()` for response field redaction
+  - `AuditHook` protocol and `NoOpAuditHook` default
+
+### Changed
+
+- `DynamoDb` key operations now resolve key attribute names via schema configuration
+  instead of hardcoded `pk`/`sk` internals.
+- README now includes key schema, guardrail, and regulated profile usage examples.
+
 ### Planned (v1.1)
 - FastAPI integration layer (`ODataService`, `ODataRouter`, Pydantic models, OpenAPI docs)
 - `$expand` support with dotted `$select` (controlled N+1 joins with batching/caching)
@@ -79,4 +102,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Upstream Contribution**: Submit DynamoDB visitor to `odata-query` PyPI project
 - **consumer_sdk Integration**: Wire `consumer_sdk` to depend on published `dynamo-odata`
 - **PyPI Publication**: Public release to Python Package Index
-- **HIPAA Readiness** (optional): Compliance profile for healthcare use cases
+- **Regulated profile support** (optional): Reusable safety helpers for regulated workloads

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,6 +192,20 @@ def build_filter(expr: str) -> ConditionBase:
 
 ## Submitting Changes
 
+### Open Source Neutrality (Required)
+
+This repository is an open-source project. Keep issue, PR, and commit content
+vendor-neutral and generally reusable.
+
+- Do not include product names, customer names, or internal project names
+    (for example, an internal codename) in titles or descriptions unless it is strictly
+    needed for technical context.
+- Do not include organization-specific datasets, identifiers, or business logic
+    in examples, tests, docs, commit messages, issue bodies, or PR descriptions.
+- Prefer generic terms such as `tenant`, `user`, `record`, and `example-table`.
+- If a real-world context motivated a change, describe it in generic language
+    focused on the technical behavior.
+
 1. **Commit messages**: Use clear, descriptive messages
    - Good: `fix: handle null values in build_filter`
    - Bad: `fixes stuff`
@@ -201,6 +215,7 @@ def build_filter(expr: str) -> ConditionBase:
 3. **Open a pull request**:
    - Reference any related issues: `Closes #123`
    - Describe what changed and why
+    - Keep wording product-neutral and remove org-specific details
    - Include any testing notes
 
 4. **Respond to feedback**: Authors will review and may request changes

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ attributes such as `PK` and `SK`, pass a schema preset when constructing the cli
 from dynamo_odata import DynamoDb, UPPERCASE_KEY_SCHEMA
 
 db = DynamoDb(
-    table_name="pathfindehr-main",
+    table_name="main-table",
     region="us-east-1",
     key_schema=UPPERCASE_KEY_SCHEMA,
 )
@@ -163,7 +163,7 @@ validation so callers cannot query unexpected partitions or use unrestricted fil
 from dynamo_odata import DynamoDb, FilterPolicy, PartitionKeyGuard, UPPERCASE_KEY_SCHEMA
 
 db = DynamoDb(
-    table_name="pathfindehr-main",
+    table_name="main-table",
     key_schema=UPPERCASE_KEY_SCHEMA,
     partition_key_guard=PartitionKeyGuard(("TENANT#",)),
     filter_policy=FilterPolicy(
@@ -180,6 +180,41 @@ items = db.get_all("TENANT#tenant1", filter="status eq 'active'", item_only=True
 
 # Rejected before query execution
 # db.get_all("DISEASE#123", filter="contains(notes, 'x')", item_only=True)
+```
+
+### Regulated Environment Profile Helpers
+
+For API layers that need repeatable controls, use the optional regulated profile helpers:
+
+These helpers provide policy primitives only. PHI/PII identification and enforcement
+rules remain the responsibility of the consuming application.
+
+```python
+from dynamo_odata import (
+    apply_response_allowlist,
+    apply_response_field_policy,
+    build_regulated_profile,
+    validate_regulated_query,
+)
+
+profile = build_regulated_profile(
+    partition_prefixes=("TENANT#",),
+    allowed_filter_fields=frozenset({"status", "name"}),
+    max_page_size=50,
+)
+
+normalized_limit = validate_regulated_query(
+    profile,
+    partition_key="TENANT#tenant1",
+    filter_text="status eq 'active'",
+    limit=25,
+)
+
+items = [
+    {"PK": "TENANT#tenant1", "SK": "1#USER#1", "name": "Ada", "status": "active"},
+]
+safe_items = apply_response_field_policy(items, profile.forbidden_response_fields)
+public_items = apply_response_allowlist(safe_items, frozenset({"name", "status"}))
 ```
 
 ### Building Filters and Projections

--- a/src/dynamo_odata/__init__.py
+++ b/src/dynamo_odata/__init__.py
@@ -8,6 +8,19 @@ from .guardrails import (
     PartitionKeyGuard,
     PartitionKeyValidationError,
 )
+from .profiles import (
+    DEFAULT_ALLOWED_COMPARATORS,
+    DEFAULT_ALLOWED_FUNCTIONS,
+    DEFAULT_FORBIDDEN_RESPONSE_FIELDS,
+    AuditHook,
+    NoOpAuditHook,
+    RegulatedProfile,
+    apply_response_allowlist,
+    apply_response_field_policy,
+    build_regulated_profile,
+    validate_page_size,
+    validate_regulated_query,
+)
 from .projection import build_projection
 from .schema import DEFAULT_KEY_SCHEMA, UPPERCASE_KEY_SCHEMA, KeySchema
 
@@ -18,10 +31,21 @@ __all__ = [
     "FilterPolicy",
     "FilterPolicyViolationError",
     "KeySchema",
+    "NoOpAuditHook",
     "PartitionKeyGuard",
     "PartitionKeyValidationError",
+    "RegulatedProfile",
     "UPPERCASE_KEY_SCHEMA",
+    "AuditHook",
+    "DEFAULT_ALLOWED_COMPARATORS",
+    "DEFAULT_ALLOWED_FUNCTIONS",
+    "DEFAULT_FORBIDDEN_RESPONSE_FIELDS",
+    "apply_response_allowlist",
+    "apply_response_field_policy",
+    "build_regulated_profile",
     "build_filter",
     "build_projection",
+    "validate_page_size",
+    "validate_regulated_query",
     "validate_filter",
 ]

--- a/src/dynamo_odata/profiles/__init__.py
+++ b/src/dynamo_odata/profiles/__init__.py
@@ -1,0 +1,27 @@
+from .regulated import (
+    DEFAULT_ALLOWED_COMPARATORS,
+    DEFAULT_ALLOWED_FUNCTIONS,
+    DEFAULT_FORBIDDEN_RESPONSE_FIELDS,
+    AuditHook,
+    NoOpAuditHook,
+    RegulatedProfile,
+    apply_response_allowlist,
+    apply_response_field_policy,
+    build_regulated_profile,
+    validate_page_size,
+    validate_regulated_query,
+)
+
+__all__ = [
+    "AuditHook",
+    "DEFAULT_ALLOWED_COMPARATORS",
+    "DEFAULT_ALLOWED_FUNCTIONS",
+    "DEFAULT_FORBIDDEN_RESPONSE_FIELDS",
+    "NoOpAuditHook",
+    "RegulatedProfile",
+    "apply_response_allowlist",
+    "apply_response_field_policy",
+    "build_regulated_profile",
+    "validate_page_size",
+    "validate_regulated_query",
+]

--- a/src/dynamo_odata/profiles/regulated.py
+++ b/src/dynamo_odata/profiles/regulated.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from ..dynamo_filter import validate_filter
+from ..guardrails import FilterPolicy, PartitionKeyGuard
+
+DEFAULT_FORBIDDEN_RESPONSE_FIELDS = frozenset(
+    {
+        "pk",
+        "sk",
+        "PK",
+        "SK",
+        "ttl",
+        "lsis1",
+        "lsis2",
+        "lsis3",
+        "lsin4",
+        "lsin5",
+        "analytics_uuid",
+    }
+)
+
+DEFAULT_ALLOWED_FUNCTIONS = frozenset(
+    {
+        "contains",
+        "startswith",
+        "tolower",
+        "exists",
+        "not_exists",
+    }
+)
+
+DEFAULT_ALLOWED_COMPARATORS = frozenset(
+    {
+        "eq",
+        "ne",
+        "lt",
+        "le",
+        "gt",
+        "ge",
+        "in",
+        "between",
+    }
+)
+
+
+class AuditHook(Protocol):
+    def on_query_allowed(
+        self,
+        *,
+        partition_key: str,
+        filter_text: str | None,
+        normalized_limit: int,
+    ) -> None: ...
+
+    def on_query_blocked(
+        self,
+        *,
+        reason: str,
+        partition_key: str,
+        filter_text: str | None,
+        requested_limit: int | None,
+    ) -> None: ...
+
+
+class NoOpAuditHook:
+    def on_query_allowed(
+        self,
+        *,
+        partition_key: str,
+        filter_text: str | None,
+        normalized_limit: int,
+    ) -> None:
+        del partition_key, filter_text, normalized_limit
+
+    def on_query_blocked(
+        self,
+        *,
+        reason: str,
+        partition_key: str,
+        filter_text: str | None,
+        requested_limit: int | None,
+    ) -> None:
+        del reason, partition_key, filter_text, requested_limit
+
+
+@dataclass(frozen=True)
+class RegulatedProfile:
+    partition_guard: PartitionKeyGuard
+    filter_policy: FilterPolicy
+    forbidden_response_fields: frozenset[str]
+    max_page_size: int
+    audit_hook: AuditHook
+
+
+def build_regulated_profile(
+    *,
+    partition_prefixes: tuple[str, ...] = ("TENANT#",),
+    allowed_filter_fields: frozenset[str] | None = None,
+    allowed_filter_functions: frozenset[str] = DEFAULT_ALLOWED_FUNCTIONS,
+    allowed_filter_comparators: frozenset[str] = DEFAULT_ALLOWED_COMPARATORS,
+    max_filter_predicates: int = 8,
+    max_filter_depth: int = 8,
+    forbidden_response_fields: frozenset[str] = DEFAULT_FORBIDDEN_RESPONSE_FIELDS,
+    max_page_size: int = 100,
+    audit_hook: AuditHook | None = None,
+) -> RegulatedProfile:
+    if max_page_size < 1:
+        raise ValueError("max_page_size must be >= 1")
+
+    return RegulatedProfile(
+        partition_guard=PartitionKeyGuard(partition_prefixes),
+        filter_policy=FilterPolicy(
+            allowed_fields=allowed_filter_fields,
+            allowed_functions=allowed_filter_functions,
+            allowed_comparators=allowed_filter_comparators,
+            max_predicates=max_filter_predicates,
+            max_depth=max_filter_depth,
+        ),
+        forbidden_response_fields=forbidden_response_fields,
+        max_page_size=max_page_size,
+        audit_hook=audit_hook or NoOpAuditHook(),
+    )
+
+
+def apply_response_field_policy(
+    items: list[dict[str, Any]],
+    forbidden_fields: frozenset[str],
+) -> list[dict[str, Any]]:
+    return [
+        {key: value for key, value in item.items() if key not in forbidden_fields}
+        for item in items
+    ]
+
+
+def apply_response_allowlist(
+    items: list[dict[str, Any]],
+    allowed_fields: frozenset[str],
+) -> list[dict[str, Any]]:
+    return [
+        {key: value for key, value in item.items() if key in allowed_fields}
+        for item in items
+    ]
+
+
+def validate_page_size(
+    limit: int | None,
+    max_page_size: int,
+    default_page_size: int | None = None,
+) -> int:
+    if max_page_size < 1:
+        raise ValueError("max_page_size must be >= 1")
+
+    normalized_default = max_page_size if default_page_size is None else default_page_size
+    if normalized_default < 1:
+        raise ValueError("default_page_size must be >= 1")
+    if normalized_default > max_page_size:
+        raise ValueError("default_page_size must be <= max_page_size")
+
+    if limit is None:
+        return normalized_default
+    if limit < 1:
+        raise ValueError("limit must be >= 1")
+    if limit > max_page_size:
+        raise ValueError(f"limit {limit} exceeds max_page_size {max_page_size}")
+    return limit
+
+
+def validate_regulated_query(
+    profile: RegulatedProfile,
+    *,
+    partition_key: str,
+    filter_text: str | None,
+    limit: int | None,
+    default_page_size: int | None = None,
+) -> int:
+    try:
+        profile.partition_guard.validate(partition_key)
+        if filter_text:
+            validate_filter(filter_text, profile.filter_policy)
+        normalized_limit = validate_page_size(
+            limit=limit,
+            max_page_size=profile.max_page_size,
+            default_page_size=default_page_size,
+        )
+    except Exception as exc:
+        profile.audit_hook.on_query_blocked(
+            reason=str(exc),
+            partition_key=partition_key,
+            filter_text=filter_text,
+            requested_limit=limit,
+        )
+        raise
+
+    profile.audit_hook.on_query_allowed(
+        partition_key=partition_key,
+        filter_text=filter_text,
+        normalized_limit=normalized_limit,
+    )
+    return normalized_limit

--- a/src/dynamo_odata/profiles/regulated.py
+++ b/src/dynamo_odata/profiles/regulated.py
@@ -153,7 +153,9 @@ def validate_page_size(
     if max_page_size < 1:
         raise ValueError("max_page_size must be >= 1")
 
-    normalized_default = max_page_size if default_page_size is None else default_page_size
+    normalized_default = (
+        max_page_size if default_page_size is None else default_page_size
+    )
     if normalized_default < 1:
         raise ValueError("default_page_size must be >= 1")
     if normalized_default > max_page_size:

--- a/tests/test_regulated_profile.py
+++ b/tests/test_regulated_profile.py
@@ -1,0 +1,173 @@
+import pytest
+
+from dynamo_odata import (
+    DEFAULT_FORBIDDEN_RESPONSE_FIELDS,
+    NoOpAuditHook,
+    apply_response_allowlist,
+    apply_response_field_policy,
+    build_regulated_profile,
+    validate_page_size,
+    validate_regulated_query,
+)
+from dynamo_odata.guardrails import FilterPolicyViolationError, PartitionKeyValidationError
+
+
+class _CaptureAuditHook:
+    def __init__(self) -> None:
+        self.allowed_calls: list[dict] = []
+        self.blocked_calls: list[dict] = []
+
+    def on_query_allowed(
+        self,
+        *,
+        partition_key: str,
+        filter_text: str | None,
+        normalized_limit: int,
+    ) -> None:
+        self.allowed_calls.append(
+            {
+                "partition_key": partition_key,
+                "filter_text": filter_text,
+                "normalized_limit": normalized_limit,
+            }
+        )
+
+    def on_query_blocked(
+        self,
+        *,
+        reason: str,
+        partition_key: str,
+        filter_text: str | None,
+        requested_limit: int | None,
+    ) -> None:
+        self.blocked_calls.append(
+            {
+                "reason": reason,
+                "partition_key": partition_key,
+                "filter_text": filter_text,
+                "requested_limit": requested_limit,
+            }
+        )
+
+
+def test_build_regulated_profile_defaults():
+    profile = build_regulated_profile()
+
+    assert profile.max_page_size == 100
+    assert profile.partition_guard.allowed_prefixes == ("TENANT#",)
+    assert profile.forbidden_response_fields == DEFAULT_FORBIDDEN_RESPONSE_FIELDS
+    assert isinstance(profile.audit_hook, NoOpAuditHook)
+
+
+def test_build_regulated_profile_with_overrides():
+    profile = build_regulated_profile(
+        partition_prefixes=("ORG#",),
+        max_page_size=25,
+        forbidden_response_fields=frozenset({"PK", "SK"}),
+        allowed_filter_fields=frozenset({"status"}),
+    )
+
+    assert profile.partition_guard.allowed_prefixes == ("ORG#",)
+    assert profile.max_page_size == 25
+    assert profile.forbidden_response_fields == frozenset({"PK", "SK"})
+    assert profile.filter_policy.allowed_fields == frozenset({"status"})
+
+
+def test_build_regulated_profile_rejects_invalid_max_page_size():
+    with pytest.raises(ValueError, match="max_page_size"):
+        build_regulated_profile(max_page_size=0)
+
+
+def test_apply_response_field_policy_strips_internal_fields():
+    items = [
+        {"PK": "TENANT#1", "SK": "1#USER#1", "name": "Ada", "ttl": 123},
+        {"PK": "TENANT#1", "SK": "1#USER#2", "name": "Grace", "active": True},
+    ]
+
+    result = apply_response_field_policy(items, frozenset({"PK", "SK", "ttl"}))
+
+    assert result == [{"name": "Ada"}, {"name": "Grace", "active": True}]
+
+
+def test_apply_response_allowlist_keeps_only_allowed_fields():
+    items = [
+        {"PK": "TENANT#1", "SK": "1#USER#1", "name": "Ada", "status": "active"},
+        {"PK": "TENANT#1", "SK": "1#USER#2", "name": "Grace", "status": "inactive"},
+    ]
+
+    result = apply_response_allowlist(items, frozenset({"name", "status"}))
+
+    assert result == [
+        {"name": "Ada", "status": "active"},
+        {"name": "Grace", "status": "inactive"},
+    ]
+
+
+def test_validate_page_size_defaults_and_bounds():
+    assert validate_page_size(limit=None, max_page_size=50, default_page_size=20) == 20
+    assert validate_page_size(limit=None, max_page_size=50) == 50
+    assert validate_page_size(limit=10, max_page_size=50) == 10
+
+    with pytest.raises(ValueError, match="limit must be >= 1"):
+        validate_page_size(limit=0, max_page_size=50)
+
+    with pytest.raises(ValueError, match="exceeds max_page_size"):
+        validate_page_size(limit=51, max_page_size=50)
+
+
+def test_validate_regulated_query_allowed_calls_audit_hook():
+    hook = _CaptureAuditHook()
+    profile = build_regulated_profile(
+        allowed_filter_fields=frozenset({"status"}),
+        max_page_size=25,
+        audit_hook=hook,
+    )
+
+    normalized_limit = validate_regulated_query(
+        profile,
+        partition_key="TENANT#a",
+        filter_text="status eq 'active'",
+        limit=10,
+    )
+
+    assert normalized_limit == 10
+    assert len(hook.allowed_calls) == 1
+    assert hook.allowed_calls[0]["partition_key"] == "TENANT#a"
+    assert hook.allowed_calls[0]["normalized_limit"] == 10
+    assert hook.blocked_calls == []
+
+
+def test_validate_regulated_query_partition_blocked_calls_audit_hook():
+    hook = _CaptureAuditHook()
+    profile = build_regulated_profile(audit_hook=hook)
+
+    with pytest.raises(PartitionKeyValidationError):
+        validate_regulated_query(
+            profile,
+            partition_key="DISEASE#x",
+            filter_text=None,
+            limit=10,
+        )
+
+    assert len(hook.blocked_calls) == 1
+    assert "must start with one of" in hook.blocked_calls[0]["reason"]
+    assert hook.allowed_calls == []
+
+
+def test_validate_regulated_query_filter_blocked_calls_audit_hook():
+    hook = _CaptureAuditHook()
+    profile = build_regulated_profile(
+        allowed_filter_fields=frozenset({"status"}),
+        audit_hook=hook,
+    )
+
+    with pytest.raises(FilterPolicyViolationError):
+        validate_regulated_query(
+            profile,
+            partition_key="TENANT#a",
+            filter_text="age gt 18",
+            limit=10,
+        )
+
+    assert len(hook.blocked_calls) == 1
+    assert "Field 'age' is not allowed" in hook.blocked_calls[0]["reason"]

--- a/tests/test_regulated_profile.py
+++ b/tests/test_regulated_profile.py
@@ -9,7 +9,10 @@ from dynamo_odata import (
     validate_page_size,
     validate_regulated_query,
 )
-from dynamo_odata.guardrails import FilterPolicyViolationError, PartitionKeyValidationError
+from dynamo_odata.guardrails import (
+    FilterPolicyViolationError,
+    PartitionKeyValidationError,
+)
 
 
 class _CaptureAuditHook:


### PR DESCRIPTION
Summary
This PR adds optional regulated profile helpers and contributor guidance for vendor-neutral open-source collaboration.

What changed
- Added regulated profile helpers under src/dynamo_odata/profiles:
  - RegulatedProfile
  - build_regulated_profile
  - validate_regulated_query
  - validate_page_size
  - apply_response_field_policy
  - apply_response_allowlist
  - AuditHook protocol and NoOpAuditHook
- Exported new profile APIs via package __init__
- Added tests in tests/test_regulated_profile.py
- Updated docs and templates:
  - README usage examples and policy ownership note
  - CHANGELOG unreleased notes
  - CONTRIBUTING and PR/issue templates for vendor-neutral language

Compliance boundary
The library provides generic policy primitives only. PHI/PII identification and enforcement remain responsibilities of consuming applications.

Validation
- Full test suite passed locally: 163 passed

Related
Closes #10