### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+---
+
+## [0.2.0] - 2026-04-14
+
 ### Added
 
 - Configurable key schema support:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dynamo-odata"
-version = "0.1.0"
+version = "0.2.0"
 description = "OData filter and projection helpers for AWS DynamoDB"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps version from 0.1.0 to 0.2.0 following merge of PR #11.

After merge, tag v0.2.0 on main to trigger PyPI release.