### PR TITLE
ci: switch PyPI publish to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Check distribution metadata
+        run: python -m twine check dist/*
+
+      - name: Upload distributions artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download distributions artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/tests/test_gsi_transact_restore.py
+++ b/tests/test_gsi_transact_restore.py
@@ -61,7 +61,7 @@ class TestQueryGsi:
             "ConsumedCapacity": None,
         }
 
-        items, cursor = db.query_gsi(
+        _, cursor = db.query_gsi(
             index_name="tenant-slug-index",
             pk_attr="tenantSlug",
             pk_value="acme",

--- a/tests/test_put_item_create_item.py
+++ b/tests/test_put_item_create_item.py
@@ -25,11 +25,6 @@ def _make_db() -> DynamoDb:
         return db
 
 
-# ---------------------------------------------------------------------------
-# put_item (sync)
-# ---------------------------------------------------------------------------
-
-
 class TestPutItem:
     def test_basic_write(self):
         db = _make_db()
@@ -55,11 +50,6 @@ class TestPutItem:
         db.put_item("TENANT#t1#USER", "1#u1", {"v": "ok"})
         kw = db.table.put_item.call_args.kwargs
         assert "ConditionExpression" not in kw
-
-
-# ---------------------------------------------------------------------------
-# put_item_async
-# ---------------------------------------------------------------------------
 
 
 class TestPutItemAsync:
@@ -88,11 +78,6 @@ class TestPutItemAsync:
             assert "ConditionExpression" not in kw
 
         asyncio.run(run())
-
-
-# ---------------------------------------------------------------------------
-# create_item (sync)
-# ---------------------------------------------------------------------------
 
 
 class TestCreateItem:
@@ -128,11 +113,6 @@ class TestCreateItem:
         db.table.put_item.return_value = {}
         db.create_item("TENANT#t1#USER", "1#u1", {"user_name": "New"})
         db.table.put_item.assert_called_once()
-
-
-# ---------------------------------------------------------------------------
-# create_item_async
-# ---------------------------------------------------------------------------
 
 
 class TestCreateItemAsync:

--- a/tests/test_update_item.py
+++ b/tests/test_update_item.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from dynamo_odata import DynamoDb, UPPERCASE_KEY_SCHEMA
+from dynamo_odata import UPPERCASE_KEY_SCHEMA, DynamoDb
 
 
 def _make_db() -> DynamoDb:
@@ -49,7 +49,8 @@ class TestUpdateItemSync:
         db.table.update_item.return_value = {"Attributes": {}}
 
         db.update_item(
-            "TENANT#t1#USER", "1#u1",
+            "TENANT#t1#USER",
+            "1#u1",
             {"PK": "should-be-stripped", "SK": "should-be-stripped", "name": "Carol"},
         )
 
@@ -99,9 +100,7 @@ class TestUpdateItemAsync:
 
         with patch("dynamo_odata.db._get_aioboto3_session") as mock_session:
             mock_session.return_value.resource.return_value = ctx
-            result = asyncio.run(
-                db.update_item_async("TENANT#t1#USER", "1#u1", {"name": "Alice", "status": "active"})
-            )
+            result = asyncio.run(db.update_item_async("TENANT#t1#USER", "1#u1", {"name": "Alice", "status": "active"}))
 
         assert result == {"name": "Alice", "status": "active"}
 
@@ -118,9 +117,7 @@ class TestUpdateItemAsync:
 
         with patch("dynamo_odata.db._get_aioboto3_session") as mock_session:
             mock_session.return_value.resource.return_value = ctx
-            asyncio.run(
-                db.update_item_async("TENANT#t1#USER", "1#u1", {"name": "Bob", "lsis3": "bob"})
-            )
+            asyncio.run(db.update_item_async("TENANT#t1#USER", "1#u1", {"name": "Bob", "lsis3": "bob"}))
 
         assert captured[0]["UpdateExpression"].startswith("SET ")
         assert "#name=:name" in captured[0]["UpdateExpression"]


### PR DESCRIPTION
## Summary
Switch the PyPI publish workflow from API-token authentication to trusted publishing via GitHub OIDC.

## Changes
- Add `permissions: id-token: write` to the publish job
- Remove token/password-based publish configuration
- Keep existing `v*` tag trigger and manual dispatch

## Why
This removes long-lived PyPI credentials from GitHub secrets and uses short-lived, identity-bound tokens issued at workflow runtime.

## Follow-up (one-time in PyPI)
Configure Trusted Publisher for:
- Owner: `one-table-labs`
- Repository: `dynamo-odata`
- Workflow: `publish.yml`
- Environment: `pypi`
