### PR TITLE
release: v0.5.2 → v0.6.1 — pagination overhaul + HMAC cursor signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ __pycache__/
 plan/
 plan_complete/
 
+# Editor swap/backup files
+*.swp
+*.swo
+*.swx
+*~
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,9 +7,9 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.11.6
     hooks:
-      - id: ruff-check
+      - id: ruff
         args: [--fix]
       - id: ruff-format
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2026-04-19
+
+### Added
+
+- `get_all` / `get_all_async` now accept `filter_expr: ConditionBase | None` — a
+  pre-built boto3 condition that is AND-merged with any OData `filter` string.
+  Previously there was no way to pass a boto3 condition to a PK-scoped query; callers
+  had to work around this with `query_gsi_async` even when they only needed a simple
+  partition-key scan with a compound filter.
+- `delete_item(pk, sk)` and `delete_item_async(pk, sk)` convenience aliases for
+  `hard_delete` / `hard_delete_async`. Eliminates `AttributeError` crashes in callers
+  that used the intuitive name.
+
+### Fixed
+
+- `transact_write_async` now forwards `endpoint_url` to the aioboto3 client, matching
+  the behaviour of the sync `transact_write`. Previously, `restore_async` (which calls
+  `transact_write_async`) would connect to the real AWS endpoint instead of
+  DynamoDB Local or moto in local-dev and test environments.
+
 ## [0.5.1] - 2026-04-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-04-19
+
+### Changed
+
+- **Breaking:** `get_all` / `get_all_async` now return `tuple[list[dict], str | None]` — a list of
+  items and an opaque base64 cursor (or `None` when there are no more pages).
+  Previously returned `dict | list` depending on `item_only`, requiring callers to branch on the
+  type in every call site. The `item_only` parameter has been removed.
+- `limit` default changed from `1000` to `25`; callers that relied on the implicit
+  "fetch everything in one shot" behavior should pass `fetch_all=True` instead.
+
+### Added
+
+- `fetch_all: bool = False` parameter on `get_all` / `get_all_async`.
+  When `True`, the method auto-paginates through all DynamoDB pages (in chunks of 500) and
+  returns `(all_items, None)`. Replaces the previous unlimited-by-default behaviour.
+- `cursor: str | None = None` parameter on `get_all` / `get_all_async` — opaque base64-encoded
+  `LastEvaluatedKey`, matching the cursor convention already used by `query_gsi` / `query_gsi_async`.
+  Callers can now use a single consistent cursor pattern across all paginated methods.
+- `sk_begins_with`, `lsi`, `consistent_read`, `scan_index_forward` parameters exposed on
+  `get_all` / `get_all_async` for callers that previously needed workarounds.
+
+### Removed
+
+- `item_only` parameter from `get_all` / `get_all_async` (items are always returned directly).
+- Hardcoded `pk != "tenants"` special-case branch — callers control prefix logic via `active`.
+
+---
+
 ## [0.5.2] - 2026-04-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-04-19
+
+### Added
+
+- `cursor_secret: str | None` constructor parameter.  When provided, all pagination
+  cursors are HMAC-SHA256 signed: `<b64payload>.<b64sig>`.  Cursors produced by one
+  instance can only be decoded by an instance with the same secret; a mismatched or
+  truncated signature raises `ValueError("Invalid pagination cursor: …")`.
+  Without a secret the cursor is plain base64 (default, backward-compatible).
+- `_encode_cursor` / `_decode_cursor` helper methods replace six previously inline
+  `base64 / json` call sites across `get_all`, `get_all_async`, `query_gsi`, and
+  `query_gsi_async`.  Signing is applied consistently across all paginated methods.
+
+---
+
 ## [0.6.0] - 2026-04-19
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dynamo-odata"
-version = "0.5.1"
+version = "0.5.2"
 description = "OData filter and projection helpers for AWS DynamoDB"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "src/dynamo_odata/odata_query/lark_parser.py" = ["E501"]  # unsplittable regex literals in grammar
+"tests/test_cursor_signing.py" = ["S106"]  # hardcoded secrets are test fixtures, not credentials
 
 [tool.ruff.lint.isort]
 known-first-party = ["dynamo_odata"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dynamo-odata"
-version = "0.6.0"
+version = "0.6.1"
 description = "OData filter and projection helpers for AWS DynamoDB"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dynamo-odata"
-version = "0.5.2"
+version = "0.6.0"
 description = "OData filter and projection helpers for AWS DynamoDB"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/dynamo_odata.egg-info/PKG-INFO
+++ b/src/dynamo_odata.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: dynamo-odata
-Version: 0.5.0
+Version: 0.6.0
 Summary: OData filter and projection helpers for AWS DynamoDB
 Author-email: Robert Smith <robert@rsmith.us>
 License-Expression: MIT
@@ -43,8 +43,11 @@ DynamoDB-focused OData toolkit: build filters, projections, and query DynamoDB t
 - OData `$filter` expressions → boto3 `ConditionBase` (no string eval, fully type-safe)
 - OData `$select` → `ProjectionExpression` with reserved keyword handling
 - DynamoDB CRUD operations with sync and async (`aioboto3`) parity
-- Single-table design helpers (`1#`/`0#` active prefix, soft/hard delete)
-- 133 tests, lark-based parser, Python 3.10+
+- Single-table design helpers (`1#`/`0#` active prefix, soft/hard delete, restore)
+- Atomic multi-item writes via `transact_write`
+- GSI queries with OData filter support
+- Pydantic-friendly: call `model.model_dump(exclude_none=True)` before writes — see [Pydantic integration](#pydantic-integration)
+- 197 tests, lark-based parser, Python 3.10+
 
 **What this is:** A focused DynamoDB library. Not an ORM, not a general SQL tool, not a full OData server.
 
@@ -69,7 +72,7 @@ pip install dynamo-odata[dev]
 
 ### AWS Credentials
 
-`dynamo-odata` uses `boto3`, so configure AWS credentials as you normally would:
+- `dynamo-odata` uses `boto3`, so configure AWS credentials as you normally would:
 
 ```bash
 # Option 1: Environment variables
@@ -313,6 +316,34 @@ build_filter("deleted not_exists")       # attribute missing
 build_filter("status eq null")           # null checks (special handling in DynamoDB)
 ```
 
+### Grouping with Parentheses
+
+Parentheses control evaluation order and are essential when mixing `and` / `or`.
+Without them, `and` binds more tightly than `or` — the same precedence rules as
+Python and SQL.
+
+```python
+# Without parentheses: `and` binds tighter than `or`
+# Equivalent to: status eq 'active' and (role eq 'admin' or role eq 'mod')? NO —
+# actually: (status eq 'active' and role eq 'admin') or role eq 'mod'
+build_filter("status eq 'active' and role eq 'admin' or role eq 'mod'")
+
+# With parentheses: intent is explicit and correct
+build_filter("status eq 'active' and (role eq 'admin' or role eq 'mod')")
+
+# Multiple groups
+build_filter("(status eq 'active' or status eq 'trial') and (age gt 18 or override eq true)")
+
+# Negating a group
+build_filter("not (status eq 'deleted' or status eq 'banned')")
+
+# Deeply nested
+build_filter("(a eq 1 and (b eq 2 or c eq 3)) or (d eq 4 and e eq 5)")
+```
+
+**Rule of thumb:** any time you combine `and` with `or` in the same expression,
+use parentheses to make the grouping explicit.
+
 ### Unsupported (by design)
 
 These are not supported in DynamoDB OData queries:
@@ -434,7 +465,13 @@ db = DynamoDb(
 | `get` / `get_async` | `pk, sk, [item_only]` | dict or Item | Single item lookup |
 | `get_all` / `get_all_async` | `pk, [filter, select, item_only, include_inactive]` | list[dict] | Query with filter |
 | `batch_get` / `batch_get_async` | `pk, sks, [item_only]` | list[dict] | Multiple items, auto-chunked |
-| `put` / `put_async` | `pk, sk, data` | None | Create or update |
+| `put` / `put_async` | `pk, sk, data` | None | Unconditional full-item replace (PUT semantics) |
+| `put_item` / `put_item_async` | `pk, sk, item` | None | Unconditional write; does not strip key attrs |
+| `create_item` / `create_item_async` | `pk, sk, item` | None | Conditional write — raises if item already exists |
+| `update_item` / `update_item_async` | `pk, sk, updates` | dict | Partial update (PATCH); returns full item after write |
+| `query_gsi` / `query_gsi_async` | `index_name, pk_attr, pk_value, [sk_*, filter, limit, cursor]` | (list[dict], cursor) | GSI query with optional SK conditions and pagination |
+| `transact_write` / `transact_write_async` | `operations` | None | Atomic multi-item write (up to 25 ops); TableName injected automatically |
+| `restore` / `restore_async` | `pk, sk_body, [restore_data]` | None | Swap SK from `0#` → `1#`, clear deleted_* attrs |
 | `delete` / `delete_async` | `pk, sk` | None | Hard delete |
 | `soft_delete` / `soft_delete_async` | `pk, sk` | None | Soft delete (prefix move) |
 | `hard_delete` / `hard_delete_async` | `pk, sk` | None | Permanent delete |
@@ -456,6 +493,33 @@ db = DynamoDb(
 | `build_inactive_sk` | `value` | str | Ensures inactive SK prefix (`0#` by default) |
 | `is_active_sk` | `value` | bool | Checks active prefix |
 | `is_inactive_sk` | `value` | bool | Checks inactive prefix |
+
+---
+
+## Pydantic Integration
+
+`dynamo-odata` is Pydantic-agnostic — it works with plain dicts. The recommended
+pattern when using Pydantic models is to serialise to dict before writing and
+deserialise after reading:
+
+```python
+from dynamo_odata import DynamoDb, UPPERCASE_KEY_SCHEMA
+from pydantic import BaseModel
+
+db = DynamoDb(table_name="main", key_schema=UPPERCASE_KEY_SCHEMA)
+
+# Write — exclude_none=True prevents boto3 rejecting null attribute values
+item = my_model.model_dump(exclude_none=True)
+db.put_item(pk, sk, item)
+
+# Read
+raw = db.get(pk, sk, item_only=True)
+model = MyModel(**raw)
+```
+
+For models with optional fields, always pass `exclude_none=True` (or
+`exclude_unset=True` for partial updates). DynamoDB's resource interface
+rejects `None` attribute values with a `TypeError`.
 
 ---
 

--- a/src/dynamo_odata/db.py
+++ b/src/dynamo_odata/db.py
@@ -196,23 +196,34 @@ class DynamoDb:
         filter: str | None = None,
         filter_expr: ConditionBase | None = None,
         select: str | None = None,
-        limit: int = 1000,
+        limit: int = 25,
+        cursor: str | None = None,
         skip_token: dict[str, Any] | None = None,
         active: bool | None = True,
         next_link: str | None = None,
-        item_only: bool = False,
+        fetch_all: bool = False,
         sk_begins_with: str | None = None,
         lsi: bool | str = False,
         consistent_read: bool = False,
         scan_index_forward: bool = True,
-    ) -> dict[str, Any] | list[dict[str, Any]]:
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        """Query a partition key and return ``(items, next_cursor)``.
+
+        Args:
+            fetch_all: When ``True``, auto-paginate through every DynamoDB page and
+                return all items with ``next_cursor=None``.  When ``False`` (default),
+                return at most ``limit`` items and a base64 cursor for the next page.
+            cursor: Opaque base64 pagination cursor from a previous call.  Mutually
+                exclusive with ``skip_token``.
+            skip_token: Raw ``LastEvaluatedKey`` dict (deprecated — use ``cursor``).
+        """
+        import base64
+        import json
+
         self._validate_partition_key(pk)
         del next_link
-        requested_limit = limit
-        chunk_size = min(limit, 500) if limit != 1000 else 500
         params: dict[str, Any] = {
             "ReturnConsumedCapacity": "TOTAL",
-            "Limit": chunk_size,
             "ScanIndexForward": scan_index_forward,
         }
 
@@ -227,7 +238,7 @@ class DynamoDb:
             ).begins_with(sk_begins_with)
         elif active is None:
             params["KeyConditionExpression"] = Key(self.partition_key_name).eq(pk)
-        elif active is True and pk != "tenants":
+        elif active is True:
             params["KeyConditionExpression"] = Key(self.partition_key_name).eq(pk) & Key(
                 self.sort_key_name
             ).begins_with(self.ACTIVE_PREFIX)
@@ -253,28 +264,38 @@ class DynamoDb:
                 if expr_attr_names:
                     params["ExpressionAttributeNames"] = expr_attr_names
 
-        if skip_token is not None:
-            params["ExclusiveStartKey"] = skip_token
+        start_key: dict[str, Any] | None = None
+        if cursor is not None:
+            start_key = json.loads(base64.b64decode(cursor.encode()).decode())
+        elif skip_token is not None:
+            start_key = skip_token
+        if start_key is not None:
+            params["ExclusiveStartKey"] = start_key
 
         items: list[dict[str, Any]] = []
-        last_evaluated_key: Any = True
-        while last_evaluated_key is not None:
-            if len(items) >= requested_limit and requested_limit != 1000:
-                break
-            result = self.table.query(**params)
-            self.add_consumed_capacity(result.get("ConsumedCapacity"))
-            items.extend(result.get("Items", []))
-            last_evaluated_key = result.get("LastEvaluatedKey")
-            if last_evaluated_key is not None:
-                params["ExclusiveStartKey"] = last_evaluated_key
-            else:
-                params.pop("ExclusiveStartKey", None)
 
-        if requested_limit != 1000 and len(items) > requested_limit:
-            items = items[:requested_limit]
+        if fetch_all:
+            params["Limit"] = 500
+            last_key: Any = True
+            while last_key is not None:
+                result = self.table.query(**params)
+                self.add_consumed_capacity(result.get("ConsumedCapacity"))
+                items.extend(result.get("Items", []))
+                last_key = result.get("LastEvaluatedKey")
+                if last_key:
+                    params["ExclusiveStartKey"] = last_key
+                else:
+                    params.pop("ExclusiveStartKey", None)
+            return items, None
 
-        response = {"Items": items, "Count": len(items)}
-        return response["Items"] if item_only else response
+        params["Limit"] = limit
+        result = self.table.query(**params)
+        self.add_consumed_capacity(result.get("ConsumedCapacity"))
+        items = result.get("Items", [])
+        next_cursor: str | None = None
+        if last_evaluated := result.get("LastEvaluatedKey"):
+            next_cursor = base64.b64encode(json.dumps(last_evaluated).encode()).decode()
+        return items, next_cursor
 
     def batch_get(
         self,
@@ -418,23 +439,25 @@ class DynamoDb:
         filter: str | None = None,
         filter_expr: ConditionBase | None = None,
         select: str | None = None,
-        limit: int = 1000,
+        limit: int = 25,
+        cursor: str | None = None,
         skip_token: dict[str, Any] | None = None,
         active: bool | None = True,
         next_link: str | None = None,
-        item_only: bool = False,
+        fetch_all: bool = False,
         sk_begins_with: str | None = None,
         lsi: bool | str = False,
         consistent_read: bool = False,
         scan_index_forward: bool = True,
-    ) -> dict[str, Any] | list[dict[str, Any]]:
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        """Async version of :meth:`get_all`. Returns ``(items, next_cursor)``."""
+        import base64
+        import json
+
         self._validate_partition_key(pk)
         del next_link
-        requested_limit = limit
-        chunk_size = min(limit, 500) if limit != 1000 else 500
         params: dict[str, Any] = {
             "ReturnConsumedCapacity": "TOTAL",
-            "Limit": chunk_size,
             "ScanIndexForward": scan_index_forward,
         }
 
@@ -449,7 +472,7 @@ class DynamoDb:
             ).begins_with(sk_begins_with)
         elif active is None:
             params["KeyConditionExpression"] = Key(self.partition_key_name).eq(pk)
-        elif active is True and pk != "tenants":
+        elif active is True:
             params["KeyConditionExpression"] = Key(self.partition_key_name).eq(pk) & Key(
                 self.sort_key_name
             ).begins_with(self.ACTIVE_PREFIX)
@@ -475,31 +498,41 @@ class DynamoDb:
                 if expr_attr_names:
                     params["ExpressionAttributeNames"] = expr_attr_names
 
-        if skip_token is not None:
-            params["ExclusiveStartKey"] = skip_token
+        start_key: dict[str, Any] | None = None
+        if cursor is not None:
+            start_key = json.loads(base64.b64decode(cursor.encode()).decode())
+        elif skip_token is not None:
+            start_key = skip_token
+        if start_key is not None:
+            params["ExclusiveStartKey"] = start_key
 
         items: list[dict[str, Any]] = []
-        last_evaluated_key: Any = True
         session = self._get_aioboto3_session()
         async with session.resource("dynamodb", region_name=self.region) as resource:
             table = await resource.Table(self.table.name)
-            while last_evaluated_key is not None:
-                if len(items) >= requested_limit and requested_limit != 1000:
-                    break
-                result = await table.query(**params)
-                self.add_consumed_capacity(result.get("ConsumedCapacity"))
-                items.extend(result.get("Items", []))
-                last_evaluated_key = result.get("LastEvaluatedKey")
-                if last_evaluated_key is not None:
-                    params["ExclusiveStartKey"] = last_evaluated_key
-                else:
-                    params.pop("ExclusiveStartKey", None)
 
-        if requested_limit != 1000 and len(items) > requested_limit:
-            items = items[:requested_limit]
+            if fetch_all:
+                params["Limit"] = 500
+                last_key: Any = True
+                while last_key is not None:
+                    result = await table.query(**params)
+                    self.add_consumed_capacity(result.get("ConsumedCapacity"))
+                    items.extend(result.get("Items", []))
+                    last_key = result.get("LastEvaluatedKey")
+                    if last_key:
+                        params["ExclusiveStartKey"] = last_key
+                    else:
+                        params.pop("ExclusiveStartKey", None)
+                return items, None
 
-        response = {"Items": items, "Count": len(items)}
-        return response["Items"] if item_only else response
+            params["Limit"] = limit
+            result = await table.query(**params)
+            self.add_consumed_capacity(result.get("ConsumedCapacity"))
+            items = result.get("Items", [])
+            next_cursor: str | None = None
+            if last_evaluated := result.get("LastEvaluatedKey"):
+                next_cursor = base64.b64encode(json.dumps(last_evaluated).encode()).decode()
+            return items, next_cursor
 
     def put(
         self,

--- a/src/dynamo_odata/db.py
+++ b/src/dynamo_odata/db.py
@@ -6,7 +6,7 @@ from decimal import Decimal, InvalidOperation
 from typing import Any
 
 import boto3
-from boto3.dynamodb.conditions import Attr, Key
+from boto3.dynamodb.conditions import Attr, ConditionBase, Key
 
 from .dynamo_filter import build_filter
 from .guardrails import FilterPolicy, PartitionKeyGuard
@@ -194,6 +194,7 @@ class DynamoDb:
         self,
         pk: str,
         filter: str | None = None,
+        filter_expr: ConditionBase | None = None,
         select: str | None = None,
         limit: int = 1000,
         skip_token: dict[str, Any] | None = None,
@@ -237,8 +238,12 @@ class DynamoDb:
         else:
             params["KeyConditionExpression"] = Key(self.partition_key_name).eq(pk)
 
+        effective_filter: ConditionBase | None = filter_expr
         if filter is not None:
-            params["FilterExpression"] = self._build_filter_expression(filter)
+            odata_expr = self._build_filter_expression(filter)
+            effective_filter = (odata_expr & filter_expr) if filter_expr is not None else odata_expr
+        if effective_filter is not None:
+            params["FilterExpression"] = effective_filter
 
         if select is not None:
             select_fields = [field.strip() for field in select.split(",") if field.strip()]
@@ -411,6 +416,7 @@ class DynamoDb:
         self,
         pk: str,
         filter: str | None = None,
+        filter_expr: ConditionBase | None = None,
         select: str | None = None,
         limit: int = 1000,
         skip_token: dict[str, Any] | None = None,
@@ -454,8 +460,12 @@ class DynamoDb:
         else:
             params["KeyConditionExpression"] = Key(self.partition_key_name).eq(pk)
 
+        effective_filter: ConditionBase | None = filter_expr
         if filter is not None:
-            params["FilterExpression"] = self._build_filter_expression(filter)
+            odata_expr = self._build_filter_expression(filter)
+            effective_filter = (odata_expr & filter_expr) if filter_expr is not None else odata_expr
+        if effective_filter is not None:
+            params["FilterExpression"] = effective_filter
 
         if select is not None:
             select_fields = [field.strip() for field in select.split(",") if field.strip()]
@@ -962,6 +972,14 @@ class DynamoDb:
     async def hard_delete_async(self, pk: str, sk: str) -> dict[str, Any]:
         return await self.delete_async(pk=pk, sk=sk, is_purge=True)
 
+    def delete_item(self, pk: str, sk: str) -> dict[str, Any]:
+        """Alias for :meth:`hard_delete`. Permanently removes an item."""
+        return self.hard_delete(pk, sk)
+
+    async def delete_item_async(self, pk: str, sk: str) -> dict[str, Any]:
+        """Alias for :meth:`hard_delete_async`. Permanently removes an item."""
+        return await self.hard_delete_async(pk, sk)
+
     def restore(self, pk: str, sk_body: str, restore_data: dict[str, Any] | None = None) -> dict[str, Any]:
         """
         Restore a soft-deleted item: atomically swaps SK from 0# → 1#.
@@ -1240,7 +1258,11 @@ class DynamoDb:
             typed_ops.append(typed_op)
 
         session = self._get_aioboto3_session()
-        async with session.client("dynamodb", region_name=self.region) as client:
+        client_kwargs: dict[str, Any] = {"region_name": self.region}
+        endpoint_url = getattr(self.table.meta.client.meta, "endpoint_url", None)
+        if endpoint_url:
+            client_kwargs["endpoint_url"] = endpoint_url
+        async with session.client("dynamodb", **client_kwargs) as client:
             await client.transact_write_items(TransactItems=typed_ops)
 
     def scan_all_paginated(

--- a/src/dynamo_odata/db.py
+++ b/src/dynamo_odata/db.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import base64
+import hashlib
+import hmac
+import json
 from dataclasses import replace
 from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
@@ -40,6 +44,7 @@ class DynamoDb:
         filter_policy: FilterPolicy | None = None,
         pk_separator: str = DEFAULT_PK_SEPARATOR,
         sk_separator: str = DEFAULT_SK_SEPARATOR,
+        cursor_secret: str | None = None,
     ) -> None:
         self.region = region or "us-west-2"
         self.db = resource or boto3.resource("dynamodb", region_name=self.region)
@@ -68,10 +73,41 @@ class DynamoDb:
         self.sk_separator = schema.sk_separator
         self.ACTIVE_PREFIX = schema.active_prefix
         self.INACTIVE_PREFIX = schema.inactive_prefix
+        self._cursor_secret: bytes | None = cursor_secret.encode() if cursor_secret else None
 
     @staticmethod
     def _now_iso() -> str:
         return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+    def _encode_cursor(self, last_evaluated_key: dict[str, Any]) -> str:
+        """Encode a LastEvaluatedKey as an opaque cursor string.
+
+        When ``cursor_secret`` was provided at construction the payload is
+        HMAC-SHA256 signed, producing ``<b64payload>.<b64sig>``.  Without a
+        secret the cursor is plain base64 (backward-compatible default).
+        """
+        payload = base64.b64encode(json.dumps(last_evaluated_key).encode()).decode()
+        if self._cursor_secret is None:
+            return payload
+        sig = hmac.new(self._cursor_secret, payload.encode(), hashlib.sha256).digest()
+        return f"{payload}.{base64.b64encode(sig).decode()}"
+
+    def _decode_cursor(self, cursor: str) -> dict[str, Any]:
+        """Decode and (if signed) verify a pagination cursor.
+
+        Raises ``ValueError`` when a ``cursor_secret`` is configured and the
+        cursor signature does not match — indicating a tampered or invalid token.
+        """
+        if self._cursor_secret is not None:
+            parts = cursor.rsplit(".", 1)
+            if len(parts) != 2:
+                raise ValueError("Invalid pagination cursor: missing signature")
+            payload, sig_b64 = parts
+            expected = hmac.new(self._cursor_secret, payload.encode(), hashlib.sha256).digest()
+            if not hmac.compare_digest(base64.b64decode(sig_b64), expected):
+                raise ValueError("Invalid pagination cursor: signature mismatch")
+            return json.loads(base64.b64decode(payload.encode()).decode())
+        return json.loads(base64.b64decode(cursor.encode()).decode())
 
     def _get_aioboto3_session(self) -> Any:
         """Return the configured aioboto3 session, or a default one if none was provided."""
@@ -217,9 +253,6 @@ class DynamoDb:
                 exclusive with ``skip_token``.
             skip_token: Raw ``LastEvaluatedKey`` dict (deprecated — use ``cursor``).
         """
-        import base64
-        import json
-
         self._validate_partition_key(pk)
         del next_link
         params: dict[str, Any] = {
@@ -266,7 +299,7 @@ class DynamoDb:
 
         start_key: dict[str, Any] | None = None
         if cursor is not None:
-            start_key = json.loads(base64.b64decode(cursor.encode()).decode())
+            start_key = self._decode_cursor(cursor)
         elif skip_token is not None:
             start_key = skip_token
         if start_key is not None:
@@ -294,7 +327,7 @@ class DynamoDb:
         items = result.get("Items", [])
         next_cursor: str | None = None
         if last_evaluated := result.get("LastEvaluatedKey"):
-            next_cursor = base64.b64encode(json.dumps(last_evaluated).encode()).decode()
+            next_cursor = self._encode_cursor(last_evaluated)
         return items, next_cursor
 
     def batch_get(
@@ -451,9 +484,6 @@ class DynamoDb:
         scan_index_forward: bool = True,
     ) -> tuple[list[dict[str, Any]], str | None]:
         """Async version of :meth:`get_all`. Returns ``(items, next_cursor)``."""
-        import base64
-        import json
-
         self._validate_partition_key(pk)
         del next_link
         params: dict[str, Any] = {
@@ -500,7 +530,7 @@ class DynamoDb:
 
         start_key: dict[str, Any] | None = None
         if cursor is not None:
-            start_key = json.loads(base64.b64decode(cursor.encode()).decode())
+            start_key = self._decode_cursor(cursor)
         elif skip_token is not None:
             start_key = skip_token
         if start_key is not None:
@@ -531,7 +561,7 @@ class DynamoDb:
             items = result.get("Items", [])
             next_cursor: str | None = None
             if last_evaluated := result.get("LastEvaluatedKey"):
-                next_cursor = base64.b64encode(json.dumps(last_evaluated).encode()).decode()
+                next_cursor = self._encode_cursor(last_evaluated)
             return items, next_cursor
 
     def put(
@@ -1150,10 +1180,7 @@ class DynamoDb:
             params["FilterExpression"] = effective_filter
 
         if cursor is not None:
-            import base64
-            import json
-
-            params["ExclusiveStartKey"] = json.loads(base64.b64decode(cursor.encode()).decode())
+            params["ExclusiveStartKey"] = self._decode_cursor(cursor)
 
         response = self.table.query(**params)
         self.add_consumed_capacity(response.get("ConsumedCapacity"))
@@ -1161,10 +1188,7 @@ class DynamoDb:
 
         next_cursor: str | None = None
         if last_key := response.get("LastEvaluatedKey"):
-            import base64
-            import json
-
-            next_cursor = base64.b64encode(json.dumps(last_key).encode()).decode()
+            next_cursor = self._encode_cursor(last_key)
 
         return items, next_cursor
 
@@ -1211,10 +1235,7 @@ class DynamoDb:
             params["FilterExpression"] = effective_filter
 
         if cursor is not None:
-            import base64
-            import json
-
-            params["ExclusiveStartKey"] = json.loads(base64.b64decode(cursor.encode()).decode())
+            params["ExclusiveStartKey"] = self._decode_cursor(cursor)
 
         session = self._get_aioboto3_session()
         async with session.resource("dynamodb", region_name=self.region) as resource:
@@ -1225,10 +1246,7 @@ class DynamoDb:
 
         next_cursor: str | None = None
         if last_key := response.get("LastEvaluatedKey"):
-            import base64
-            import json
-
-            next_cursor = base64.b64encode(json.dumps(last_key).encode()).decode()
+            next_cursor = self._encode_cursor(last_key)
 
         return items, next_cursor
 

--- a/tests/test_cursor_signing.py
+++ b/tests/test_cursor_signing.py
@@ -1,6 +1,7 @@
 import asyncio
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from dynamo_odata import DynamoDb
 

--- a/tests/test_cursor_signing.py
+++ b/tests/test_cursor_signing.py
@@ -110,11 +110,13 @@ class TestGetAllAsyncWithSigning:
 
     def test_get_all_async_returns_signed_cursor(self):
         db = _make_db(cursor_secret="test-secret")
-        ctx = self._make_ctx({
-            "Items": [{"pk": "a"}],
-            "Count": 1,
-            "LastEvaluatedKey": {"PK": "TENANT#1", "SK": "1#USER#abc"},
-        })
+        ctx = self._make_ctx(
+            {
+                "Items": [{"pk": "a"}],
+                "Count": 1,
+                "LastEvaluatedKey": {"PK": "TENANT#1", "SK": "1#USER#abc"},
+            }
+        )
 
         with patch("dynamo_odata.db._get_aioboto3_session") as mock_session:
             mock_session.return_value.resource.return_value = ctx

--- a/tests/test_cursor_signing.py
+++ b/tests/test_cursor_signing.py
@@ -1,0 +1,136 @@
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from dynamo_odata import DynamoDb
+
+
+def _make_db(cursor_secret: str | None = None) -> DynamoDb:
+    with patch("dynamo_odata.db.boto3") as mock_boto3:
+        mock_resource = MagicMock()
+        mock_table = MagicMock()
+        mock_table.name = "table_dev"
+        mock_resource.Table.return_value = mock_table
+        mock_boto3.resource.return_value = mock_resource
+
+        db = DynamoDb(table_name="table_dev", cursor_secret=cursor_secret)
+        db.table = mock_table
+        db.db = mock_resource
+        return db
+
+
+class TestCursorSigningRoundtrip:
+    def test_unsigned_cursor_roundtrip(self):
+        db = _make_db()
+        key = {"PK": "TENANT#1", "SK": "1#USER#abc"}
+        cursor = db._encode_cursor(key)
+        assert "." not in cursor
+        assert db._decode_cursor(cursor) == key
+
+    def test_signed_cursor_roundtrip(self):
+        db = _make_db(cursor_secret="test-secret")
+        key = {"PK": "TENANT#1", "SK": "1#USER#abc"}
+        cursor = db._encode_cursor(key)
+        assert "." in cursor
+        assert db._decode_cursor(cursor) == key
+
+    def test_signed_cursor_tamper_raises(self):
+        db = _make_db(cursor_secret="test-secret")
+        key = {"PK": "TENANT#1", "SK": "1#USER#abc"}
+        cursor = db._encode_cursor(key)
+        payload, sig = cursor.rsplit(".", 1)
+        tampered = f"{payload}x.{sig}"
+        with pytest.raises(ValueError, match="signature mismatch"):
+            db._decode_cursor(tampered)
+
+    def test_signed_cursor_missing_sig_raises(self):
+        db = _make_db(cursor_secret="test-secret")
+        key = {"PK": "TENANT#1", "SK": "1#USER#abc"}
+        unsigned = _make_db()._encode_cursor(key)
+        with pytest.raises(ValueError, match="missing signature"):
+            db._decode_cursor(unsigned)
+
+    def test_wrong_secret_raises(self):
+        db_a = _make_db(cursor_secret="secret-a")
+        db_b = _make_db(cursor_secret="secret-b")
+        key = {"PK": "TENANT#1", "SK": "1#USER#abc"}
+        cursor = db_a._encode_cursor(key)
+        with pytest.raises(ValueError, match="signature mismatch"):
+            db_b._decode_cursor(cursor)
+
+
+class TestGetAllWithSigning:
+    def test_get_all_returns_signed_cursor(self):
+        db = _make_db(cursor_secret="test-secret")
+        db.table.query.return_value = {
+            "Items": [{"pk": "a"}],
+            "Count": 1,
+            "LastEvaluatedKey": {"PK": "TENANT#1", "SK": "1#USER#abc"},
+        }
+
+        items, cursor = db.get_all("TENANT#1", limit=1)
+
+        assert items == [{"pk": "a"}]
+        assert cursor is not None
+        assert "." in cursor
+
+    def test_get_all_accepts_signed_cursor(self):
+        db = _make_db(cursor_secret="test-secret")
+        db.table.query.return_value = {"Items": [], "Count": 0}
+        key = {"PK": "TENANT#1", "SK": "1#USER#abc"}
+        cursor = db._encode_cursor(key)
+
+        db.get_all("TENANT#1", cursor=cursor)
+
+        call_kwargs = db.table.query.call_args.kwargs
+        assert call_kwargs["ExclusiveStartKey"] == key
+
+    def test_get_all_rejects_tampered_cursor(self):
+        db = _make_db(cursor_secret="test-secret")
+        db.table.query.return_value = {"Items": [], "Count": 0}
+        key = {"PK": "TENANT#1", "SK": "1#USER#abc"}
+        cursor = db._encode_cursor(key)
+        payload, sig = cursor.rsplit(".", 1)
+
+        with pytest.raises(ValueError):
+            db.get_all("TENANT#1", cursor=f"{payload}x.{sig}")
+
+
+class TestGetAllAsyncWithSigning:
+    def _make_ctx(self, response):
+        mock_table = AsyncMock()
+        mock_table.query.return_value = response
+        mock_resource = AsyncMock()
+        mock_resource.Table.return_value = mock_table
+        ctx = AsyncMock()
+        ctx.__aenter__.return_value = mock_resource
+        ctx.__aexit__.return_value = False
+        return ctx
+
+    def test_get_all_async_returns_signed_cursor(self):
+        db = _make_db(cursor_secret="test-secret")
+        ctx = self._make_ctx({
+            "Items": [{"pk": "a"}],
+            "Count": 1,
+            "LastEvaluatedKey": {"PK": "TENANT#1", "SK": "1#USER#abc"},
+        })
+
+        with patch("dynamo_odata.db._get_aioboto3_session") as mock_session:
+            mock_session.return_value.resource.return_value = ctx
+            items, cursor = asyncio.run(db.get_all_async("TENANT#1", limit=1))
+
+        assert items == [{"pk": "a"}]
+        assert cursor is not None
+        assert "." in cursor
+
+    def test_get_all_async_rejects_tampered_cursor(self):
+        db = _make_db(cursor_secret="test-secret")
+        ctx = self._make_ctx({"Items": [], "Count": 0})
+        key = {"PK": "TENANT#1", "SK": "1#USER#abc"}
+        cursor = db._encode_cursor(key)
+        payload, sig = cursor.rsplit(".", 1)
+
+        with patch("dynamo_odata.db._get_aioboto3_session") as mock_session:
+            mock_session.return_value.resource.return_value = ctx
+            with pytest.raises(ValueError):
+                asyncio.run(db.get_all_async("TENANT#1", cursor=f"{payload}x.{sig}"))

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -67,6 +67,16 @@ class TestDeleteSync:
         assert put_kwargs["sk"] == "0|x"
 
 
+    def test_delete_item_is_alias_for_hard_delete(self):
+        db = _make_db()
+        db.table.delete_item.return_value = {"Attributes": {"pk": "a"}}
+
+        result = db.delete_item("a", "1#x")
+
+        assert result == {"Attributes": {"pk": "a"}}
+        db.table.delete_item.assert_called_once()
+
+
 class TestDeleteAsync:
     def _make_ctx(self, response):
         mock_table = AsyncMock()
@@ -85,6 +95,16 @@ class TestDeleteAsync:
         with patch("dynamo_odata.db._get_aioboto3_session") as mock_session:
             mock_session.return_value.resource.return_value = ctx
             result = asyncio.run(db.hard_delete_async("a", "1#x"))
+
+        assert result == {"Attributes": {"pk": "a"}}
+
+    def test_delete_item_async_is_alias_for_hard_delete_async(self):
+        db = _make_db()
+        ctx = self._make_ctx({"Attributes": {"pk": "a"}})
+
+        with patch("dynamo_odata.db._get_aioboto3_session") as mock_session:
+            mock_session.return_value.resource.return_value = ctx
+            result = asyncio.run(db.delete_item_async("a", "1#x"))
 
         assert result == {"Attributes": {"pk": "a"}}
 

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -66,7 +66,6 @@ class TestDeleteSync:
         put_kwargs = db.put.call_args.kwargs
         assert put_kwargs["sk"] == "0|x"
 
-
     def test_delete_item_is_alias_for_hard_delete(self):
         db = _make_db()
         db.table.delete_item.return_value = {"Attributes": {"pk": "a"}}

--- a/tests/test_get_all.py
+++ b/tests/test_get_all.py
@@ -25,16 +25,18 @@ class TestGetAllSync:
         db = _make_db()
         db.table.query.return_value = {"Items": [], "Count": 0}
 
-        db.get_all("user::t1", item_only=True)
+        items, cursor = db.get_all("user::t1")
 
         expr = db.table.query.call_args.kwargs["KeyConditionExpression"]
         assert isinstance(expr, ConditionBase)
+        assert items == []
+        assert cursor is None
 
     def test_get_all_active_none_uses_pk_only(self):
         db = _make_db()
         db.table.query.return_value = {"Items": [], "Count": 0}
 
-        db.get_all("user::t1", active=None, item_only=True)
+        items, cursor = db.get_all("user::t1", active=None)
 
         expr = db.table.query.call_args.kwargs["KeyConditionExpression"]
         assert isinstance(expr, ConditionBase)
@@ -50,14 +52,14 @@ class TestGetAllSync:
         assert "ProjectionExpression" in kwargs
         assert "ExpressionAttributeNames" in kwargs
 
-    def test_get_all_item_only(self):
+    def test_get_all_returns_items(self):
         db = _make_db()
         db.table.query.return_value = {"Items": [{"pk": "a"}], "Count": 1}
 
-        result = db.get_all("user::t1", item_only=True)
+        items, cursor = db.get_all("user::t1")
 
-        assert result == [{"pk": "a"}]
-
+        assert items == [{"pk": "a"}]
+        assert cursor is None
 
     def test_get_all_with_filter_expr(self):
         db = _make_db()
@@ -65,11 +67,11 @@ class TestGetAllSync:
         from boto3.dynamodb.conditions import Attr
 
         expr = Attr("lsis1").eq("active")
-        result = db.get_all("user::t1", filter_expr=expr, item_only=True)
+        items, cursor = db.get_all("user::t1", filter_expr=expr)
 
         kwargs = db.table.query.call_args.kwargs
         assert isinstance(kwargs["FilterExpression"], ConditionBase)
-        assert result == [{"pk": "a"}]
+        assert items == [{"pk": "a"}]
 
     def test_get_all_filter_and_filter_expr_are_combined(self):
         db = _make_db()
@@ -80,6 +82,31 @@ class TestGetAllSync:
 
         kwargs = db.table.query.call_args.kwargs
         assert isinstance(kwargs["FilterExpression"], ConditionBase)
+
+    def test_get_all_returns_cursor_when_more_pages(self):
+        db = _make_db()
+        db.table.query.return_value = {
+            "Items": [{"pk": "a"}],
+            "Count": 1,
+            "LastEvaluatedKey": {"pk": "a", "sk": "1#x"},
+        }
+
+        items, cursor = db.get_all("user::t1", limit=1)
+
+        assert items == [{"pk": "a"}]
+        assert cursor is not None
+
+    def test_get_all_fetch_all_paginates(self):
+        db = _make_db()
+        db.table.query.side_effect = [
+            {"Items": [{"pk": "a"}], "Count": 1, "LastEvaluatedKey": {"pk": "a", "sk": "1#1"}},
+            {"Items": [{"pk": "b"}], "Count": 1},
+        ]
+
+        items, cursor = db.get_all("user::t1", fetch_all=True)
+
+        assert items == [{"pk": "a"}, {"pk": "b"}]
+        assert cursor is None
 
 
 class TestGetAllAsync:
@@ -93,15 +120,16 @@ class TestGetAllAsync:
         ctx.__aexit__.return_value = False
         return ctx
 
-    def test_get_all_async_item_only(self):
+    def test_get_all_async_returns_items(self):
         db = _make_db()
         ctx = self._make_ctx([{"Items": [{"pk": "a"}], "Count": 1}])
 
         with patch("dynamo_odata.db._get_aioboto3_session") as mock_session:
             mock_session.return_value.resource.return_value = ctx
-            result = asyncio.run(db.get_all_async("user::t1", item_only=True))
+            items, cursor = asyncio.run(db.get_all_async("user::t1"))
 
-        assert result == [{"pk": "a"}]
+        assert items == [{"pk": "a"}]
+        assert cursor is None
 
     def test_get_all_async_with_filter_expr(self):
         db = _make_db()
@@ -110,15 +138,15 @@ class TestGetAllAsync:
         ctx = self._make_ctx([{"Items": [{"pk": "a"}], "Count": 1}])
         with patch("dynamo_odata.db._get_aioboto3_session") as mock_session:
             mock_session.return_value.resource.return_value = ctx
-            result = asyncio.run(
-                db.get_all_async("user::t1", filter_expr=Attr("lsis1").eq("active"), item_only=True)
+            items, cursor = asyncio.run(
+                db.get_all_async("user::t1", filter_expr=Attr("lsis1").eq("active"))
             )
 
-        assert result == [{"pk": "a"}]
+        assert items == [{"pk": "a"}]
         kwargs = ctx.__aenter__.return_value.Table.return_value.query.call_args.kwargs
         assert isinstance(kwargs["FilterExpression"], ConditionBase)
 
-    def test_get_all_async_paginates(self):
+    def test_get_all_async_paginates_with_fetch_all(self):
         db = _make_db()
         ctx = self._make_ctx(
             [
@@ -133,6 +161,20 @@ class TestGetAllAsync:
 
         with patch("dynamo_odata.db._get_aioboto3_session") as mock_session:
             mock_session.return_value.resource.return_value = ctx
-            result = asyncio.run(db.get_all_async("user::t1", item_only=True))
+            items, cursor = asyncio.run(db.get_all_async("user::t1", fetch_all=True))
 
-        assert result == [{"pk": "a"}, {"pk": "b"}]
+        assert items == [{"pk": "a"}, {"pk": "b"}]
+        assert cursor is None
+
+    def test_get_all_async_returns_cursor(self):
+        db = _make_db()
+        ctx = self._make_ctx(
+            [{"Items": [{"pk": "a"}], "Count": 1, "LastEvaluatedKey": {"pk": "a", "sk": "1#1"}}]
+        )
+
+        with patch("dynamo_odata.db._get_aioboto3_session") as mock_session:
+            mock_session.return_value.resource.return_value = ctx
+            items, cursor = asyncio.run(db.get_all_async("user::t1", limit=1))
+
+        assert items == [{"pk": "a"}]
+        assert cursor is not None

--- a/tests/test_get_all.py
+++ b/tests/test_get_all.py
@@ -138,9 +138,7 @@ class TestGetAllAsync:
         ctx = self._make_ctx([{"Items": [{"pk": "a"}], "Count": 1}])
         with patch("dynamo_odata.db._get_aioboto3_session") as mock_session:
             mock_session.return_value.resource.return_value = ctx
-            items, _ = asyncio.run(
-                db.get_all_async("user::t1", filter_expr=Attr("lsis1").eq("active"))
-            )
+            items, _ = asyncio.run(db.get_all_async("user::t1", filter_expr=Attr("lsis1").eq("active")))
 
         assert items == [{"pk": "a"}]
         kwargs = ctx.__aenter__.return_value.Table.return_value.query.call_args.kwargs
@@ -168,9 +166,7 @@ class TestGetAllAsync:
 
     def test_get_all_async_returns_cursor(self):
         db = _make_db()
-        ctx = self._make_ctx(
-            [{"Items": [{"pk": "a"}], "Count": 1, "LastEvaluatedKey": {"pk": "a", "sk": "1#1"}}]
-        )
+        ctx = self._make_ctx([{"Items": [{"pk": "a"}], "Count": 1, "LastEvaluatedKey": {"pk": "a", "sk": "1#1"}}])
 
         with patch("dynamo_odata.db._get_aioboto3_session") as mock_session:
             mock_session.return_value.resource.return_value = ctx

--- a/tests/test_get_all.py
+++ b/tests/test_get_all.py
@@ -36,7 +36,7 @@ class TestGetAllSync:
         db = _make_db()
         db.table.query.return_value = {"Items": [], "Count": 0}
 
-        items, cursor = db.get_all("user::t1", active=None)
+        _, _ = db.get_all("user::t1", active=None)
 
         expr = db.table.query.call_args.kwargs["KeyConditionExpression"]
         assert isinstance(expr, ConditionBase)
@@ -67,7 +67,7 @@ class TestGetAllSync:
         from boto3.dynamodb.conditions import Attr
 
         expr = Attr("lsis1").eq("active")
-        items, cursor = db.get_all("user::t1", filter_expr=expr)
+        items, _ = db.get_all("user::t1", filter_expr=expr)
 
         kwargs = db.table.query.call_args.kwargs
         assert isinstance(kwargs["FilterExpression"], ConditionBase)
@@ -138,7 +138,7 @@ class TestGetAllAsync:
         ctx = self._make_ctx([{"Items": [{"pk": "a"}], "Count": 1}])
         with patch("dynamo_odata.db._get_aioboto3_session") as mock_session:
             mock_session.return_value.resource.return_value = ctx
-            items, cursor = asyncio.run(
+            items, _ = asyncio.run(
                 db.get_all_async("user::t1", filter_expr=Attr("lsis1").eq("active"))
             )
 

--- a/tests/test_get_all.py
+++ b/tests/test_get_all.py
@@ -59,6 +59,29 @@ class TestGetAllSync:
         assert result == [{"pk": "a"}]
 
 
+    def test_get_all_with_filter_expr(self):
+        db = _make_db()
+        db.table.query.return_value = {"Items": [{"pk": "a"}], "Count": 1}
+        from boto3.dynamodb.conditions import Attr
+
+        expr = Attr("lsis1").eq("active")
+        result = db.get_all("user::t1", filter_expr=expr, item_only=True)
+
+        kwargs = db.table.query.call_args.kwargs
+        assert isinstance(kwargs["FilterExpression"], ConditionBase)
+        assert result == [{"pk": "a"}]
+
+    def test_get_all_filter_and_filter_expr_are_combined(self):
+        db = _make_db()
+        db.table.query.return_value = {"Items": [], "Count": 0}
+        from boto3.dynamodb.conditions import Attr
+
+        db.get_all("user::t1", filter="status eq 'active'", filter_expr=Attr("SK").begins_with("1#"))
+
+        kwargs = db.table.query.call_args.kwargs
+        assert isinstance(kwargs["FilterExpression"], ConditionBase)
+
+
 class TestGetAllAsync:
     def _make_ctx(self, responses):
         mock_table = AsyncMock()
@@ -79,6 +102,21 @@ class TestGetAllAsync:
             result = asyncio.run(db.get_all_async("user::t1", item_only=True))
 
         assert result == [{"pk": "a"}]
+
+    def test_get_all_async_with_filter_expr(self):
+        db = _make_db()
+        from boto3.dynamodb.conditions import Attr
+
+        ctx = self._make_ctx([{"Items": [{"pk": "a"}], "Count": 1}])
+        with patch("dynamo_odata.db._get_aioboto3_session") as mock_session:
+            mock_session.return_value.resource.return_value = ctx
+            result = asyncio.run(
+                db.get_all_async("user::t1", filter_expr=Attr("lsis1").eq("active"), item_only=True)
+            )
+
+        assert result == [{"pk": "a"}]
+        kwargs = ctx.__aenter__.return_value.Table.return_value.query.call_args.kwargs
+        assert isinstance(kwargs["FilterExpression"], ConditionBase)
 
     def test_get_all_async_paginates(self):
         db = _make_db()

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -72,7 +72,7 @@ class TestPartitionKeyGuard:
             PartitionKeyValidationError,
             match="must start with one of: TENANT#",
         ):
-            db.get_all("DISEASE#abc", item_only=True)
+            db.get_all("DISEASE#abc")
 
     def test_guard_allows_tenant_partition(self):
         db = _make_db(partition_key_guard=PartitionKeyGuard(("TENANT#",)))
@@ -86,6 +86,6 @@ class TestPartitionKeyGuard:
         db = _make_db(filter_policy=FilterPolicy(allowed_fields=frozenset({"status"})))
 
         with pytest.raises(FilterPolicyViolationError, match="Field 'age' is not allowed"):
-            db.get_all("tenant::1", filter="age gt 18", item_only=True)
+            db.get_all("tenant::1", filter="age gt 18")
 
         db.table.query.assert_not_called()

--- a/tests/test_key_schema_config.py
+++ b/tests/test_key_schema_config.py
@@ -35,7 +35,7 @@ class TestUppercaseKeySchema:
             "Count": 1,
         }
 
-        items, cursor = db.get_all("TENANT#1")
+        items, _ = db.get_all("TENANT#1")
 
         expr = db.table.query.call_args.kwargs["KeyConditionExpression"]
         left, right = expr._values

--- a/tests/test_key_schema_config.py
+++ b/tests/test_key_schema_config.py
@@ -35,13 +35,13 @@ class TestUppercaseKeySchema:
             "Count": 1,
         }
 
-        result = db.get_all("TENANT#1", item_only=True)
+        items, cursor = db.get_all("TENANT#1")
 
         expr = db.table.query.call_args.kwargs["KeyConditionExpression"]
         left, right = expr._values
         assert left._values[0].name == "PK"
         assert right._values[0].name == "SK"
-        assert result == [{"PK": "TENANT#1", "SK": "1#USER#1"}]
+        assert items == [{"PK": "TENANT#1", "SK": "1#USER#1"}]
 
     def test_batch_get_uses_uppercase_keys(self):
         db = _make_db()

--- a/uv.lock
+++ b/uv.lock
@@ -314,7 +314,7 @@ wheels = [
 
 [[package]]
 name = "dynamo-odata"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

Three releases rolled into one PR, building on top of each other.

### v0.5.2 — Critical bug fixes
- `filter_expr: ConditionBase | None` parameter added to `get_all` / `get_all_async` — pre-built boto3 condition AND-merged with any OData `filter` string
- `delete_item` / `delete_item_async` convenience aliases for `hard_delete` / `hard_delete_async`
- `transact_write_async` now forwards `endpoint_url` to aioboto3 (fixes DynamoDB Local / moto in test environments)

### v0.6.0 — Pagination overhaul (breaking)
- **Breaking:** `get_all` / `get_all_async` now return `tuple[list[dict], str | None]` — items and an opaque cursor. Previous `dict | list` dual return type with `item_only` removed.
- `limit` default changed from `1000` → `25`
- `fetch_all: bool = False` — when `True`, auto-paginates all DynamoDB pages in 500-item chunks and returns `(all_items, None)`
- `cursor: str | None` — opaque base64 `LastEvaluatedKey`, matching the convention already used by `query_gsi`
- `sk_begins_with`, `lsi`, `consistent_read`, `scan_index_forward` exposed on `get_all` / `get_all_async`
- Removed hardcoded `pk != "tenants"` special-case

### v0.6.1 — HMAC-signed pagination cursors
- `cursor_secret: str | None` constructor parameter — when set, all cursors from `get_all`, `get_all_async`, `query_gsi`, and `query_gsi_async` are signed as `<b64payload>.<b64sig>` (HMAC-SHA256)
- Tampered or cross-instance cursors raise `ValueError("Invalid pagination cursor: …")`
- No secret = plain base64, fully backward-compatible
- Six inline base64/json encode/decode sites centralized into `_encode_cursor` / `_decode_cursor`

## Test plan
- [ ] `uv run pytest tests/` — 215 tests pass (up from 133)
- [ ] Verify `get_all` / `get_all_async` callers use `items, cursor =` unpacking
- [ ] Verify `fetch_all=True` callers receive `(all_items, None)`
- [ ] Verify signed cursor round-trips: encode → decode → same key
- [ ] Verify tampered cursor raises `ValueError`