### PR TITLE
fix: handle Decimal in _encode_cursor for numeric DynamoDB keys (v0.6.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2026-04-23
+
+### Fixed
+
+- `_encode_cursor` now handles `Decimal` values in `LastEvaluatedKey` (DynamoDB returns
+  numeric key attributes as `Decimal`).  Previously `json.dumps` raised `TypeError` when
+  paginating tables with numeric partition or sort keys.  Decimals are now serialized as
+  `int`; any other non-serializable type falls back to `str`.
+
+---
+
 ## [0.6.1] - 2026-04-19
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dynamo-odata"
-version = "0.6.1"
+version = "0.6.2"
 description = "OData filter and projection helpers for AWS DynamoDB"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/dynamo_odata/db.py
+++ b/src/dynamo_odata/db.py
@@ -91,7 +91,9 @@ class DynamoDb:
         HMAC-SHA256 signed, producing ``<b64payload>.<b64sig>``.  Without a
         secret the cursor is plain base64 (backward-compatible default).
         """
-        payload = base64.b64encode(json.dumps(last_evaluated_key).encode()).decode()
+        payload = base64.b64encode(
+            json.dumps(last_evaluated_key, default=lambda o: int(o) if isinstance(o, Decimal) else str(o)).encode()
+        ).decode()
         if self._cursor_secret is None:
             return payload
         sig = hmac.new(self._cursor_secret, payload.encode(), hashlib.sha256).digest()

--- a/uv.lock
+++ b/uv.lock
@@ -314,7 +314,7 @@ wheels = [
 
 [[package]]
 name = "dynamo-odata"
-version = "0.6.0"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

- `_encode_cursor` raised `TypeError` when paginating tables with numeric (int/float) partition or sort keys because DynamoDB returns those as `Decimal` and `json.dumps` can't serialize `Decimal` by default.
- Added a `default` handler to `json.dumps`: `Decimal` → `int`, anything else → `str`.
- Bumped to **v0.6.2**.

## Test plan

- [ ] Run existing pagination test suite (`uv run pytest tests/ -x`) — all pass
- [ ] Manually verify cursor round-trip on a table with a numeric hash key produces a valid cursor and decodes correctly