### PR TITLE
feat(examples): add sync, async, and filter/projection examples

### DIFF
--- a/examples/async_example.py
+++ b/examples/async_example.py
@@ -1,0 +1,131 @@
+"""Async CRUD operations with dynamo-odata.
+
+Run against a real DynamoDB table:
+    python examples/async_example.py
+
+Requires: pip install dynamo-odata[async]
+Set TABLE_NAME and REGION to match your table.
+"""
+
+import asyncio
+
+from dynamo_odata import DynamoDb
+
+TABLE_NAME = "my-table"
+REGION = "us-east-1"
+
+TENANT_PK = "tenant::acme"
+
+
+async def main() -> None:
+    db = DynamoDb(table_name=TABLE_NAME, region=REGION)
+
+    # ── Create ────────────────────────────────────────────────────────────────
+
+    await db.create_item_async(
+        pk=TENANT_PK,
+        sk=db.build_active_sk("user::alice"),
+        item={
+            "name": "Alice",
+            "email": "alice@example.com",
+            "role": "admin",
+        },
+    )
+
+    await db.create_item_async(
+        pk=TENANT_PK,
+        sk=db.build_active_sk("user::bob"),
+        item={
+            "name": "Bob",
+            "email": "bob@example.com",
+            "role": "viewer",
+        },
+    )
+
+    print("Created two users.")
+
+    # ── Read (single item) ────────────────────────────────────────────────────
+
+    alice = await db.get_async(
+        pk=TENANT_PK,
+        sk=db.build_active_sk("user::alice"),
+        item_only=True,
+    )
+    print("Fetched:", alice)
+
+    # ── Update ────────────────────────────────────────────────────────────────
+
+    await db.update_item_async(
+        pk=TENANT_PK,
+        sk=db.build_active_sk("user::alice"),
+        updates={"role": "owner"},
+    )
+    print("Updated Alice's role to owner.")
+
+    # ── List with pagination ───────────────────────────────────────────────────
+
+    items, next_cursor = await db.get_all_async(pk=TENANT_PK, limit=10)
+    print(f"Page 1: {len(items)} item(s). Has next page: {next_cursor is not None}")
+
+    # ── Fetch all pages in one call ────────────────────────────────────────────
+
+    all_items, _ = await db.get_all_async(pk=TENANT_PK, fetch_all=True)
+    print(f"All items across all pages: {len(all_items)}")
+
+    # ── Batch get ─────────────────────────────────────────────────────────────
+
+    batch = await db.batch_get_async(
+        pk=TENANT_PK,
+        sks=[db.build_active_sk("user::alice"), db.build_active_sk("user::bob")],
+    )
+    print(f"Batch fetched {len(batch)} items.")
+
+    # ── Transact write (atomic multi-item) ────────────────────────────────────
+
+    await db.transact_write_async(
+        operations=[
+            {
+                "Update": {
+                    "Key": {
+                        db.partition_key_name: TENANT_PK,
+                        db.sort_key_name: db.build_active_sk("user::alice"),
+                    },
+                    "UpdateExpression": "SET #s = :s",
+                    "ExpressionAttributeNames": {"#s": "status"},
+                    "ExpressionAttributeValues": {":s": "verified"},
+                }
+            },
+            {
+                "Update": {
+                    "Key": {
+                        db.partition_key_name: TENANT_PK,
+                        db.sort_key_name: db.build_active_sk("user::bob"),
+                    },
+                    "UpdateExpression": "SET #s = :s",
+                    "ExpressionAttributeNames": {"#s": "status"},
+                    "ExpressionAttributeValues": {":s": "verified"},
+                }
+            },
+        ]
+    )
+    print("Atomically verified both users.")
+
+    # ── Soft delete ───────────────────────────────────────────────────────────
+
+    await db.soft_delete_async(pk=TENANT_PK, sk=db.build_active_sk("user::bob"))
+    print("Soft-deleted Bob.")
+
+    # ── Restore ───────────────────────────────────────────────────────────────
+
+    await db.restore_async(pk=TENANT_PK, sk_body="user::bob")
+    print("Restored Bob.")
+
+    # ── Cleanup ───────────────────────────────────────────────────────────────
+
+    await db.hard_delete_async(pk=TENANT_PK, sk=db.build_active_sk("user::alice"))
+    await db.hard_delete_async(pk=TENANT_PK, sk=db.build_active_sk("user::bob"))
+    print("Cleaned up.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/filters_and_projections.py
+++ b/examples/filters_and_projections.py
@@ -1,0 +1,95 @@
+"""OData filter and projection expressions with dynamo-odata.
+
+Demonstrates standalone use of build_filter / build_projection, plus
+passing OData expressions directly through DynamoDb query methods.
+
+Run:
+    python examples/filters_and_projections.py
+"""
+
+from dynamo_odata import DynamoDb, build_filter, build_projection
+
+# ── build_filter: OData → boto3 ConditionBase ─────────────────────────────────
+
+# Equality
+cond = build_filter("status eq 'active'")
+print(cond)  # Attr('status').eq('active')
+
+# Comparison operators
+cond = build_filter("age gt 30")
+print(cond)  # Attr('age').gt(30)
+
+cond = build_filter("score ge 90 and score le 100")
+print(cond)  # Attr('score').gte(90) & Attr('score').lte(100)
+
+# String functions
+cond = build_filter("startswith(email, 'alice')")
+print(cond)  # Attr('email').begins_with('alice')
+
+cond = build_filter("contains(tags, 'urgent')")
+print(cond)  # Attr('tags').contains('urgent')
+
+# not / or
+cond = build_filter("not (status eq 'deleted')")
+print(cond)  # ~Attr('status').eq('deleted')
+
+cond = build_filter("role eq 'admin' or role eq 'owner'")
+print(cond)  # Attr('role').eq('admin') | Attr('role').eq('owner')
+
+# in (member-of list)
+cond = build_filter("role in ('admin', 'owner', 'editor')")
+print(cond)
+
+print("build_filter examples done.\n")
+
+# ── build_projection: field list → ProjectionExpression ───────────────────────
+
+proj_expr, attr_names = build_projection(["name", "email", "role"])
+print("ProjectionExpression:", proj_expr)
+print("ExpressionAttributeNames:", attr_names)
+
+# Reserved keyword handling — 'status' is a DynamoDB reserved word
+proj_expr, attr_names = build_projection(["name", "status", "timestamp"])
+print("ProjectionExpression (with reserved words):", proj_expr)
+print("ExpressionAttributeNames:", attr_names)
+
+print("build_projection examples done.\n")
+
+# ── Passing OData filters through DynamoDb query methods ─────────────────────
+
+TABLE_NAME = "my-table"
+REGION = "us-east-1"
+TENANT_PK = "tenant::acme"
+
+db = DynamoDb(table_name=TABLE_NAME, region=REGION)
+
+# Filter active users by role using OData expression string
+items, cursor = db.get_all(
+    pk=TENANT_PK,
+    filter="role eq 'admin'",
+    limit=25,
+)
+print(f"Admin users: {len(items)}")
+
+# Combine OData filter with field projection
+items, cursor = db.get_all(
+    pk=TENANT_PK,
+    filter="status eq 'active' and role ne 'viewer'",
+    select="name,email,role",
+    limit=25,
+)
+print(f"Active non-viewers (name/email/role only): {len(items)}")
+
+# Resume from a cursor (pagination)
+if cursor:
+    page2, _ = db.get_all(pk=TENANT_PK, cursor=cursor, limit=25)
+    print(f"Page 2: {len(page2)} item(s)")
+
+# GSI query with OData filter
+items, cursor = db.query_gsi(
+    index_name="by-email-index",
+    pk_attr="email",
+    pk_value="alice@example.com",
+    filter="role eq 'admin'",
+)
+print(f"GSI result: {len(items)} item(s)")

--- a/examples/sync_example.py
+++ b/examples/sync_example.py
@@ -1,0 +1,91 @@
+"""Sync CRUD operations with dynamo-odata.
+
+Run against a real DynamoDB table:
+    python examples/sync_example.py
+
+Requires AWS credentials in the environment or ~/.aws/credentials.
+Set TABLE_NAME and REGION to match your table.
+"""
+
+from dynamo_odata import DynamoDb
+
+TABLE_NAME = "my-table"
+REGION = "us-east-1"
+
+db = DynamoDb(table_name=TABLE_NAME, region=REGION)
+
+TENANT_PK = db.build_pk("tenant", "acme")
+
+# ── Create ────────────────────────────────────────────────────────────────────
+
+db.create_item(
+    pk=TENANT_PK,
+    sk=db.build_active_sk("user::alice"),
+    item={
+        "name": "Alice",
+        "email": "alice@example.com",
+        "role": "admin",
+        "status": "active",
+    },
+)
+
+db.create_item(
+    pk=TENANT_PK,
+    sk=db.build_active_sk("user::bob"),
+    item={
+        "name": "Bob",
+        "email": "bob@example.com",
+        "role": "viewer",
+        "status": "active",
+    },
+)
+
+print("Created two users.")
+
+# ── Read (single item) ────────────────────────────────────────────────────────
+
+alice = db.get(pk=TENANT_PK, sk=db.build_active_sk("user::alice"), item_only=True)
+print("Fetched:", alice)
+
+# ── Update ────────────────────────────────────────────────────────────────────
+
+db.update_item(
+    pk=TENANT_PK,
+    sk=db.build_active_sk("user::alice"),
+    updates={"role": "owner"},
+)
+print("Updated Alice's role to owner.")
+
+# ── List all active items (paginated) ─────────────────────────────────────────
+
+items, next_cursor = db.get_all(pk=TENANT_PK, limit=10)
+print(f"Got {len(items)} item(s). More pages: {next_cursor is not None}")
+
+# ── Batch get ─────────────────────────────────────────────────────────────────
+
+batch = db.batch_get(
+    pk=TENANT_PK,
+    sks=[db.build_active_sk("user::alice"), db.build_active_sk("user::bob")],
+)
+print(f"Batch fetched {len(batch)} items.")
+
+# ── Soft delete ───────────────────────────────────────────────────────────────
+
+db.soft_delete(pk=TENANT_PK, sk=db.build_active_sk("user::bob"))
+print("Soft-deleted Bob (SK prefix flipped to 0#).")
+
+# Confirm Bob no longer appears in active listing
+active_items, _ = db.get_all(pk=TENANT_PK)
+active_names = [i.get("name") for i in active_items]
+print("Active users after soft-delete:", active_names)
+
+# ── Restore ───────────────────────────────────────────────────────────────────
+
+db.restore(pk=TENANT_PK, sk_body="user::bob")
+print("Restored Bob.")
+
+# ── Hard delete ───────────────────────────────────────────────────────────────
+
+db.hard_delete(pk=TENANT_PK, sk=db.build_active_sk("user::alice"))
+db.hard_delete(pk=TENANT_PK, sk=db.build_active_sk("user::bob"))
+print("Hard-deleted both users — table is clean.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "src/dynamo_odata/odata_query/lark_parser.py" = ["E501"]  # unsplittable regex literals in grammar
 "tests/test_cursor_signing.py" = ["S106"]  # hardcoded secrets are test fixtures, not credentials
+"examples/*.py" = ["T201"]  # print is the intended output mechanism for runnable examples
 
 [tool.ruff.lint.isort]
 known-first-party = ["dynamo_odata"]


### PR DESCRIPTION
Closes #5

## Summary

- `examples/sync_example.py` — full CRUD lifecycle using the sync API (create, get, update, get_all with pagination, batch_get, soft_delete, restore, hard_delete)
- `examples/async_example.py` — same lifecycle using async counterparts, plus transact_write_async and fetch_all pagination
- `examples/filters_and_projections.py` — standalone build_filter / build_projection usage, plus OData filter and $select strings passed through get_all and query_gsi