### PR TITLE
feat: examples directory and async endpoint_url support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.3] - 2026-04-23
+
+### Added
+
+- `endpoint_url: str | None` constructor parameter on `DynamoDb`.  When provided it
+  is forwarded to every async aioboto3 resource and `__aenter__` context-manager
+  session, enabling connection to a local DynamoDB endpoint (e.g. DynamoDB Local or
+  LocalStack) from async code paths.  The sync `boto3.resource` path already accepted
+  a custom `resource` argument; this closes the gap for async callers.
+
+---
+
 ## [0.6.2] - 2026-04-23
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dynamo-odata"
-version = "0.6.2"
+version = "0.6.3"
 description = "OData filter and projection helpers for AWS DynamoDB"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/dynamo_odata/db.py
+++ b/src/dynamo_odata/db.py
@@ -48,10 +48,12 @@ class DynamoDb:
         pk_separator: str = DEFAULT_PK_SEPARATOR,
         sk_separator: str = DEFAULT_SK_SEPARATOR,
         cursor_secret: str | None = None,
+        endpoint_url: str | None = None,
     ) -> None:
         self.region = region or "us-west-2"
         self.db = resource or boto3.resource("dynamodb", region_name=self.region)
         self._async_session = async_session
+        self._endpoint_url = endpoint_url
         self.table = self.db.Table(table_name)
         self.consumed_capacity: float = 0.0
         if key_schema is None:
@@ -120,6 +122,12 @@ class DynamoDb:
         """Return the configured aioboto3 session, or a default one if none was provided."""
         return _get_aioboto3_session(self._async_session)
 
+    def _async_resource_kwargs(self) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {"region_name": self.region}
+        if self._endpoint_url:
+            kwargs["endpoint_url"] = self._endpoint_url
+        return kwargs
+
     @asynccontextmanager
     async def _async_resource(self):
         """Yield a DynamoDB async resource, reusing the shared one when available."""
@@ -127,12 +135,12 @@ class DynamoDb:
             yield self._shared_resource
         else:
             session = self._get_aioboto3_session()
-            async with session.resource("dynamodb", region_name=self.region) as resource:
+            async with session.resource("dynamodb", **self._async_resource_kwargs()) as resource:
                 yield resource
 
     async def __aenter__(self) -> DynamoDb:
         session = self._get_aioboto3_session()
-        self._resource_cm = session.resource("dynamodb", region_name=self.region)
+        self._resource_cm = session.resource("dynamodb", **self._async_resource_kwargs())
         self._shared_resource = await self._resource_cm.__aenter__()
         return self
 


### PR DESCRIPTION
## Summary

- Adds `examples/` directory with three runnable examples: sync, async, and filter/projection patterns
- Adds `endpoint_url: str | None` constructor parameter to `DynamoDb` — forwarded to all async aioboto3 sessions, enabling local DynamoDB (DynamoDB Local / LocalStack) from async callers
- Bumps version to `0.6.3`

## Changes

**`src/dynamo_odata/db.py`**
- New `endpoint_url` param on `__init__`
- New `_async_resource_kwargs()` helper — centralises region + endpoint_url for async resource creation
- `_async_resource()` and `__aenter__` now use `_async_resource_kwargs()`

**`examples/`** (three new files)
- `sync_example.py` — basic CRUD with the sync API
- `async_example.py` — same operations using async/context-manager API
- `filters_and_projections.py` — OData filter strings and field projection

## Test plan

- [ ] `uv run pytest tests/ -x` passes
- [ ] Spot-check examples against a real or local DynamoDB table