### PR TITLE
feat: sort fallback, offset cursors, and ODataService.list_async (v0.8.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .venv/
+.worktrees/
 __pycache__/
 *.pyc
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-05-02
+
+### Added
+
+- **Offset cursor helpers** — `DynamoDb.encode_offset_cursor(offset)`, `is_offset_cursor(payload)`,
+  and `decode_offset_cursor(payload)` enable opaque pagination over Python-sorted result sets.
+  Offset cursors share the same transport and HMAC signing as LSI (`LastEvaluatedKey`) cursors.
+- **`sort_items` utility** — standalone, DynamoDB-free helper that sorts a list of item dicts by
+  a single field with case-insensitive string comparison and missing-field-last semantics.
+  Exported from `dynamo_odata` directly.
+- **Extended `ODataQueryParams`** — four new parameters: `sort` (field name), `order`
+  (`"asc"`/`"desc"`, default `"desc"`), `limit` (int, default 25), and `cursor` (opaque string).
+  All existing OData params (`$filter`, `$select`, `$expand`, `$top`, `$skipToken`) are unchanged.
+- **`ODataService.list_async`** — high-level method that routes to the correct DynamoDB execution
+  strategy based on the requested sort field and a caller-supplied `sort_field_map`:
+  - **LSI path** — field in map → `get_all_async` with `lsi` and `scan_index_forward`.
+  - **Python-sort path** — field not in map → fetch-all, `sort_items`, offset-cursor pagination.
+  - **Unsorted path** — no sort → standard `get_all_async` with limit/cursor.
+  Returns `{"items": [...], "next_cursor": str | None}` on all paths. `$expand` pipeline runs
+  on the page slice (not the full fetched set) on the Python-sort path.
+
+---
+
 ## [0.7.1] - 2026-04-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -378,6 +378,68 @@ See `examples/fastapi_expand.py` for a complete runnable app with Swagger UI.
 
 ---
 
+### `list_async` — sort fallback and REST-style params
+
+`ODataService.list_async` is a higher-level alternative to `query_items` that accepts
+both OData and REST-convention params and automatically routes to the right DynamoDB
+execution strategy:
+
+| Scenario | Strategy |
+| --- | --- |
+| `sort` field is in `sort_field_map` | LSI query (`get_all_async` with `lsi=` + `scan_index_forward`) |
+| `sort` field is **not** in `sort_field_map` | Fetch all → `sort_items` in Python → offset-cursor pagination |
+| No `sort` | Standard `get_all_async` with `limit`/`cursor` |
+
+```python
+from dynamo_odata.fastapi import ODataQueryParams, ODataService
+
+svc = ODataService(expand_config={"owner": ExpandConfig(...)})
+
+@app.get("/files")
+async def list_files(params: ODataQueryParams = Depends()):
+    return await svc.list_async(
+        db=db,
+        pk=f"TENANT#{tenant_id}",
+        params=params,
+        sort_field_map={
+            "name":       ("lsi-s3-index", "lsis3"),
+            "created_at": ("lsi-s1-index", "lsis1"),
+            # fields NOT listed here are sorted in Python
+        },
+    )
+```
+
+All nine query params are available on every route:
+
+| Param | Convention | Default | Effect |
+| --- | --- | --- | --- |
+| `$filter` | OData | — | Filter expression |
+| `$select` | OData | — | Field projection |
+| `$expand` | OData | — | FK expansion |
+| `$top` | OData | — | Page size (takes precedence over `limit`) |
+| `$skipToken` | OData | — | Cursor (takes precedence over `cursor`) |
+| `sort` | REST | — | Sort field name |
+| `order` | REST | `"desc"` | `"asc"` or `"desc"` |
+| `limit` | REST | `25` | Page size |
+| `cursor` | REST | — | Opaque pagination cursor |
+
+Return shape is always `{"items": [...], "next_cursor": str | None}`.
+
+See `examples/fastapi_list.py` for a complete runnable app.
+
+#### `sort_items`
+
+A standalone utility for case-insensitive, missing-field-last in-memory sorting:
+
+```python
+from dynamo_odata import sort_items
+
+sorted_items = sort_items(items, field="name", direction="asc")
+# items missing "name" sort last regardless of direction
+```
+
+---
+
 ## Filter Expressions (OData)
 
 ### Supported Operators

--- a/examples/fastapi_list.py
+++ b/examples/fastapi_list.py
@@ -1,0 +1,102 @@
+"""
+FastAPI + ODataService.list_async example.
+
+Demonstrates the three routing strategies in list_async:
+  - LSI sort  (field is in sort_field_map)
+  - Python-sort fallback  (field is not in sort_field_map)
+  - Unsorted  (no sort param)
+
+Both OData-convention (?$top, ?$skipToken) and REST-convention
+(?limit, ?cursor, ?sort, ?order) params are accepted simultaneously.
+
+Run:
+    pip install dynamo-odata[fastapi,async]
+    uvicorn examples.fastapi_list:app --reload
+
+Then open http://localhost:8000/docs to explore the API interactively.
+
+Sample curl commands:
+    # Unsorted, default limit 25
+    curl "http://localhost:8000/files"
+
+    # LSI sort on name (asc), REST-style params
+    curl "http://localhost:8000/files?sort=name&order=asc&limit=10"
+
+    # Python-sort fallback on mime_type (not in LSI map)
+    curl "http://localhost:8000/files?sort=mime_type&order=asc&limit=10"
+
+    # OData-style top + skipToken
+    curl "http://localhost:8000/files?%24top=5"
+
+    # Paginate with next_cursor from a previous response
+    curl "http://localhost:8000/files?sort=name&cursor=<next_cursor>"
+"""
+
+from fastapi import Depends, FastAPI
+
+from dynamo_odata import DynamoDb
+from dynamo_odata.expand import ExpandConfig
+from dynamo_odata.fastapi import ODataQueryParams, ODataService
+
+app = FastAPI(
+    title="dynamo-odata list_async example",
+    docs_url="/docs",
+)
+
+# ─── DynamoDB setup ───────────────────────────────────────────────────────────
+# Replace table_name and region with your real values.
+db = DynamoDb(table_name="demo-table", region="us-west-2")
+
+TENANT_PK = "TENANT#demo"
+USER_PK = "USER#demo"
+
+# ─── expand config ────────────────────────────────────────────────────────────
+EXPAND_CONFIG: dict[str, ExpandConfig] = {
+    "owner": ExpandConfig(
+        local_key="owner_user_id",
+        target_pk=USER_PK,
+        remote_key="user_id",
+        target_sk_prefix="USER#",
+    ),
+}
+
+# ─── sort field map ───────────────────────────────────────────────────────────
+# Maps a sort field name to (lsi_index_name, lsi_sort_attribute).
+# Fields NOT in this map are sorted in Python (fetch-all + sort_items).
+SORT_FIELD_MAP = {
+    "name":       ("lsi-s3-index", "lsis3"),
+    "created_at": ("lsi-s1-index", "lsis1"),
+}
+
+svc = ODataService(expand_config=EXPAND_CONFIG)
+
+
+async def get_db() -> DynamoDb:
+    return db
+
+
+# ─── endpoints ────────────────────────────────────────────────────────────────
+
+
+@app.get("/files")
+async def list_files(
+    params: ODataQueryParams = Depends(),
+    db: DynamoDb = Depends(get_db),
+):
+    """List files with sort, pagination, and optional owner expansion.
+
+    Supports both OData params ($top, $skipToken, $filter, $select, $expand)
+    and REST params (limit, cursor, sort, order).
+
+    Routing:
+    - sort=name or sort=created_at  → LSI index on DynamoDB
+    - sort=mime_type (any other)    → Python-side sort (fetch all, sort, slice)
+    - no sort                       → standard DynamoDB scan with limit/cursor
+    """
+    tenant_id = "demo"  # in production, extract from JWT / request context
+    return await svc.list_async(
+        db=db,
+        pk=f"TENANT#{tenant_id}",
+        params=params,
+        sort_field_map=SORT_FIELD_MAP,
+    )

--- a/examples/fastapi_list.py
+++ b/examples/fastapi_list.py
@@ -64,7 +64,7 @@ EXPAND_CONFIG: dict[str, ExpandConfig] = {
 # Maps a sort field name to (lsi_index_name, lsi_sort_attribute).
 # Fields NOT in this map are sorted in Python (fetch-all + sort_items).
 SORT_FIELD_MAP = {
-    "name":       ("lsi-s3-index", "lsis3"),
+    "name": ("lsi-s3-index", "lsis3"),
     "created_at": ("lsi-s1-index", "lsis1"),
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dynamo-odata"
-version = "0.7.1"
+version = "0.8.0"
 description = "OData filter and projection helpers for AWS DynamoDB"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "src/dynamo_odata/odata_query/lark_parser.py" = ["E501"]  # unsplittable regex literals in grammar
 "tests/test_cursor_signing.py" = ["S106"]  # hardcoded secrets are test fixtures, not credentials
+"tests/test_offset_cursor.py" = ["S106"]   # hardcoded secrets are test fixtures, not credentials
+"tests/test_params.py" = ["S105", "S106"]  # skip_token test values are not passwords
+"tests/test_list_async.py" = ["S106"]      # hardcoded skip_token values are test fixtures
 "examples/*.py" = ["T201"]  # print is the intended output mechanism for runnable examples
 
 [tool.ruff.lint.isort]

--- a/src/dynamo_odata/__init__.py
+++ b/src/dynamo_odata/__init__.py
@@ -27,12 +27,13 @@ from .schema import DEFAULT_KEY_SCHEMA, UPPERCASE_KEY_SCHEMA, KeySchema
 from .utils import sort_items
 
 __all__ = [
-    "AstToDynamoConditionVisitor",
-    "AuditHook",
     "DEFAULT_ALLOWED_COMPARATORS",
     "DEFAULT_ALLOWED_FUNCTIONS",
     "DEFAULT_FORBIDDEN_RESPONSE_FIELDS",
     "DEFAULT_KEY_SCHEMA",
+    "UPPERCASE_KEY_SCHEMA",
+    "AstToDynamoConditionVisitor",
+    "AuditHook",
     "DynamoDb",
     "ExpandConfig",
     "FilterPolicy",
@@ -42,7 +43,6 @@ __all__ = [
     "PartitionKeyGuard",
     "PartitionKeyValidationError",
     "RegulatedProfile",
-    "UPPERCASE_KEY_SCHEMA",
     "apply_dotted_select",
     "apply_response_allowlist",
     "apply_response_field_policy",
@@ -51,8 +51,8 @@ __all__ = [
     "build_regulated_profile",
     "expand_items_async",
     "parse_expand",
+    "sort_items",
     "validate_filter",
     "validate_page_size",
     "validate_regulated_query",
-    "sort_items",
 ]

--- a/src/dynamo_odata/__init__.py
+++ b/src/dynamo_odata/__init__.py
@@ -24,6 +24,7 @@ from .profiles import (
 )
 from .projection import build_projection
 from .schema import DEFAULT_KEY_SCHEMA, UPPERCASE_KEY_SCHEMA, KeySchema
+from .utils import sort_items
 
 __all__ = [
     "AstToDynamoConditionVisitor",
@@ -53,4 +54,5 @@ __all__ = [
     "validate_filter",
     "validate_page_size",
     "validate_regulated_query",
+    "sort_items",
 ]

--- a/src/dynamo_odata/db.py
+++ b/src/dynamo_odata/db.py
@@ -118,6 +118,20 @@ class DynamoDb:
             return json.loads(base64.b64decode(payload.encode()).decode())
         return json.loads(base64.b64decode(cursor.encode()).decode())
 
+    def encode_offset_cursor(self, offset: int) -> str:
+        """Return an opaque cursor representing a Python-side pagination offset."""
+        return self._encode_cursor({"__type": "offset", "offset": offset})
+
+    @staticmethod
+    def is_offset_cursor(cursor_payload: dict) -> bool:
+        """Return True if the decoded cursor payload is an offset cursor."""
+        return cursor_payload.get("__type") == "offset"
+
+    @staticmethod
+    def decode_offset_cursor(cursor_payload: dict) -> int:
+        """Extract the integer offset from a decoded offset-cursor payload."""
+        return int(cursor_payload["offset"])
+
     def _get_aioboto3_session(self) -> Any:
         """Return the configured aioboto3 session, or a default one if none was provided."""
         return _get_aioboto3_session(self._async_session)

--- a/src/dynamo_odata/expand.py
+++ b/src/dynamo_odata/expand.py
@@ -32,13 +32,9 @@ async def expand_items_async(
         return items
 
     if len(expand_specs) > _MAX_ALIASES:
-        raise ValueError(
-            f"Too many $expand aliases ({len(expand_specs)}); maximum is {_MAX_ALIASES}."
-        )
+        raise ValueError(f"Too many $expand aliases ({len(expand_specs)}); maximum is {_MAX_ALIASES}.")
     if len(items) > _MAX_BASE_ITEMS:
-        raise ValueError(
-            f"Too many base items ({len(items)}) when $expand is active; maximum is {_MAX_BASE_ITEMS}."
-        )
+        raise ValueError(f"Too many base items ({len(items)}) when $expand is active; maximum is {_MAX_BASE_ITEMS}.")
 
     async def _fetch_alias(alias: str, cfg: ExpandConfig) -> tuple[str, dict[str, Any]]:
         fk_values = list({item[cfg.local_key] for item in items if item.get(cfg.local_key) is not None})

--- a/src/dynamo_odata/expand.py
+++ b/src/dynamo_odata/expand.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from .db import DynamoDb
@@ -41,11 +41,14 @@ async def expand_items_async(
         if not fk_values:
             return alias, {}
         sks = [f"{cfg.target_sk_prefix}{fk}" for fk in fk_values]
-        results = await db.batch_get_async(
-            cfg.target_pk,
-            sks,
-            fields=list(cfg.fields) if cfg.fields is not None else None,
-            item_only=True,
+        results = cast(
+            list[dict[str, Any]],
+            await db.batch_get_async(
+                cfg.target_pk,
+                sks,
+                fields=list(cfg.fields) if cfg.fields is not None else None,
+                item_only=True,
+            ),
         )
         lookup: dict[str, Any] = {r[cfg.remote_key]: r for r in results if cfg.remote_key in r}
         return alias, lookup

--- a/src/dynamo_odata/fastapi/params.py
+++ b/src/dynamo_odata/fastapi/params.py
@@ -16,9 +16,17 @@ class ODataQueryParams:
         expand: str | None = Query(None, alias="$expand"),
         top: int | None = Query(None, alias="$top"),
         skip_token: str | None = Query(None, alias="$skipToken"),
+        sort: str | None = Query(None, alias="sort"),
+        order: str = Query("desc", alias="order"),
+        limit: int = Query(25, alias="limit"),
+        cursor: str | None = Query(None, alias="cursor"),
     ) -> None:
         self.filter = filter
         self.select = select
         self.expand = expand
         self.top = top
         self.skip_token = skip_token
+        self.sort = sort
+        self.order = order
+        self.limit = limit
+        self.cursor = cursor

--- a/src/dynamo_odata/fastapi/service.py
+++ b/src/dynamo_odata/fastapi/service.py
@@ -10,6 +10,7 @@ except ImportError as e:
     raise ImportError("dynamo-odata[fastapi] is required — pip install dynamo-odata[fastapi]") from e
 
 from ..expand import ExpandConfig, apply_dotted_select, expand_items_async, parse_expand
+from ..utils import sort_items
 
 if TYPE_CHECKING:
     from ..db import DynamoDb
@@ -77,3 +78,67 @@ class ODataService:
             items = await expand_items_async(items, expand_specs, db)
         items = apply_dotted_select(items, params.select)
         return {"value": items, "@odata.nextLink": next_link}
+
+    async def list_async(
+        self,
+        db: DynamoDb,
+        pk: str,
+        params: ODataQueryParams,
+        sort_field_map: dict[str, tuple[str, str]] | None = None,
+    ) -> dict[str, Any]:
+        effective_limit = params.top or params.limit
+        effective_cursor = params.skip_token or params.cursor
+        expand_specs = _resolve_expand_specs(params.expand, params.select, self.expand_config)
+        base_sel = _base_select(params.select, expand_specs)
+
+        if params.sort and sort_field_map and params.sort in sort_field_map:
+            # LSI path
+            lsi_index, _ = sort_field_map[params.sort]
+            items, next_cursor = await db.get_all_async(
+                pk=pk,
+                filter=params.filter,
+                select=base_sel,
+                limit=effective_limit,
+                cursor=effective_cursor,
+                lsi=lsi_index,
+                scan_index_forward=(params.order == "asc"),
+            )
+        elif params.sort:
+            # Python-sort path — fetch all, sort in memory, slice
+            offset = 0
+            if effective_cursor is not None:
+                cursor_payload = db._decode_cursor(effective_cursor)
+                if db.is_offset_cursor(cursor_payload):
+                    offset = db.decode_offset_cursor(cursor_payload)
+
+            all_items, _ = await db.get_all_async(
+                pk=pk,
+                filter=params.filter,
+                select=base_sel,
+                fetch_all=True,
+            )
+            all_items = sort_items(all_items, params.sort, params.order)
+            page = all_items[offset : offset + effective_limit]
+            next_cursor = (
+                db.encode_offset_cursor(offset + len(page))
+                if len(page) == effective_limit
+                else None
+            )
+            if expand_specs:
+                page = await expand_items_async(page, expand_specs, db)
+            page = apply_dotted_select(page, params.select)
+            return {"items": page, "next_cursor": next_cursor}
+        else:
+            # Unsorted path
+            items, next_cursor = await db.get_all_async(
+                pk=pk,
+                filter=params.filter,
+                select=base_sel,
+                limit=effective_limit,
+                cursor=effective_cursor,
+            )
+
+        if expand_specs:
+            items = await expand_items_async(items, expand_specs, db)
+        items = apply_dotted_select(items, params.select)
+        return {"items": items, "next_cursor": next_cursor}

--- a/src/dynamo_odata/fastapi/service.py
+++ b/src/dynamo_odata/fastapi/service.py
@@ -119,11 +119,7 @@ class ODataService:
             )
             all_items = sort_items(all_items, params.sort, params.order)
             page = all_items[offset : offset + effective_limit]
-            next_cursor = (
-                db.encode_offset_cursor(offset + len(page))
-                if len(page) == effective_limit
-                else None
-            )
+            next_cursor = db.encode_offset_cursor(offset + len(page)) if len(page) == effective_limit else None
             if expand_specs:
                 page = await expand_items_async(page, expand_specs, db)
             page = apply_dotted_select(page, params.select)

--- a/src/dynamo_odata/utils.py
+++ b/src/dynamo_odata/utils.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def sort_items(
+    items: list[dict[str, Any]],
+    field: str,
+    direction: str = "asc",
+) -> list[dict[str, Any]]:
+    """Sort a list of DynamoDB items by a single field.
+
+    Items missing the sort field are sorted last regardless of direction.
+    String comparison is case-insensitive.
+
+    Args:
+        items: List of item dicts to sort (not mutated — a new list is returned).
+        field: Attribute name to sort by.
+        direction: ``"asc"`` (default) or ``"desc"``.
+
+    Returns:
+        A new list sorted by ``field``.
+
+    Raises:
+        ValueError: If ``direction`` is not ``"asc"`` or ``"desc"``.
+    """
+    if direction not in ("asc", "desc"):
+        raise ValueError(f"direction must be 'asc' or 'desc', got {direction!r}")
+
+    reverse = direction == "desc"
+    _MISSING = object()
+
+    def sort_key(item: dict[str, Any]) -> tuple:
+        val = item.get(field, _MISSING)
+        if val is _MISSING:
+            # asc (no reverse): (1, "") > (0, val) → last ✓
+            # desc (reverse): (-1, "") < (0, val) → last after inversion ✓
+            return (-1, "") if reverse else (1, "")
+        if isinstance(val, str):
+            return (0, val.lower())
+        return (0, val)
+
+    return sorted(items, key=sort_key, reverse=reverse)

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -163,10 +163,7 @@ class TestExpandItemsAsync:
         assert call_pks == {"USER#t1"}
 
     def test_max_aliases_guardrail(self):
-        specs = {
-            f"alias{i}": ExpandConfig(local_key=f"fk{i}", target_pk="PK", remote_key="id")
-            for i in range(4)
-        }
+        specs = {f"alias{i}": ExpandConfig(local_key=f"fk{i}", target_pk="PK", remote_key="id") for i in range(4)}
         items = [{"id": "1"}]
         db = MagicMock()
 

--- a/tests/test_list_async.py
+++ b/tests/test_list_async.py
@@ -1,0 +1,251 @@
+"""Tests for ODataService.list_async."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dynamo_odata import DynamoDb
+from dynamo_odata.expand import ExpandConfig
+from dynamo_odata.fastapi import ODataQueryParams, ODataService
+
+
+# ─── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _params(
+    filter=None,
+    select=None,
+    expand=None,
+    top=None,
+    skip_token=None,
+    sort=None,
+    order="desc",
+    limit=25,
+    cursor=None,
+) -> ODataQueryParams:
+    p = object.__new__(ODataQueryParams)
+    p.filter = filter
+    p.select = select
+    p.expand = expand
+    p.top = top
+    p.skip_token = skip_token
+    p.sort = sort
+    p.order = order
+    p.limit = limit
+    p.cursor = cursor
+    return p
+
+
+def _mock_db(items=None, cursor=None) -> MagicMock:
+    """Minimal mock db — no real cursor methods."""
+    db = MagicMock()
+    db.get_all_async = AsyncMock(return_value=(items or [], cursor))
+    db.batch_get_async = AsyncMock(return_value=[])
+    return db
+
+
+def _real_db() -> DynamoDb:
+    """Real DynamoDb instance with patched boto3 for cursor method tests."""
+    with patch("dynamo_odata.db.boto3") as mock_boto3:
+        mock_resource = MagicMock()
+        mock_table = MagicMock()
+        mock_table.name = "table_dev"
+        mock_resource.Table.return_value = mock_table
+        mock_boto3.resource.return_value = mock_resource
+        db = DynamoDb(table_name="table_dev")
+        db.table = mock_table
+        db.db = mock_resource
+        return db
+
+
+SORT_MAP = {
+    "name": ("lsi-s3-index", "lsis3"),
+    "status": ("lsi-s1-index", "lsis1"),
+}
+
+# ─── LSI path ─────────────────────────────────────────────────────────────────
+
+
+class TestListAsyncLsiPath:
+    def test_lsi_path_calls_get_all_async_with_correct_index(self):
+        db = _mock_db(items=[{"name": "a"}])
+        svc = ODataService()
+        asyncio.run(svc.list_async(db, "PK#t1", _params(sort="name", order="asc"), SORT_MAP))
+        call_kwargs = db.get_all_async.call_args[1]
+        assert call_kwargs["lsi"] == "lsi-s3-index"
+
+    def test_lsi_path_scan_index_forward_true_for_asc(self):
+        db = _mock_db()
+        svc = ODataService()
+        asyncio.run(svc.list_async(db, "PK#t1", _params(sort="name", order="asc"), SORT_MAP))
+        call_kwargs = db.get_all_async.call_args[1]
+        assert call_kwargs["scan_index_forward"] is True
+
+    def test_lsi_path_scan_index_forward_false_for_desc(self):
+        db = _mock_db()
+        svc = ODataService()
+        asyncio.run(svc.list_async(db, "PK#t1", _params(sort="name", order="desc"), SORT_MAP))
+        call_kwargs = db.get_all_async.call_args[1]
+        assert call_kwargs["scan_index_forward"] is False
+
+    def test_lsi_path_returns_cursor_as_is(self):
+        db = _mock_db(items=[{"name": "a"}], cursor="lsi-tok")
+        svc = ODataService()
+        result = asyncio.run(svc.list_async(db, "PK#t1", _params(sort="name"), SORT_MAP))
+        assert result["next_cursor"] == "lsi-tok"
+
+    def test_lsi_path_return_shape(self):
+        db = _mock_db(items=[{"name": "a"}])
+        svc = ODataService()
+        result = asyncio.run(svc.list_async(db, "PK#t1", _params(sort="name"), SORT_MAP))
+        assert "items" in result
+        assert "next_cursor" in result
+        assert "@odata.nextLink" not in result
+
+
+# ─── Python-sort path ─────────────────────────────────────────────────────────
+
+
+class TestListAsyncPythonSortPath:
+    def test_python_sort_calls_get_all_async_with_fetch_all(self):
+        db = _mock_db(items=[{"score": 1}])
+        svc = ODataService()
+        asyncio.run(svc.list_async(db, "PK#t1", _params(sort="score"), SORT_MAP))
+        call_kwargs = db.get_all_async.call_args[1]
+        assert call_kwargs.get("fetch_all") is True
+
+    def test_python_sort_first_page_has_next_cursor_when_full(self):
+        items = [{"n": i} for i in range(5)]
+        db = _mock_db(items=items)
+        svc = ODataService()
+        result = asyncio.run(svc.list_async(db, "PK#t1", _params(sort="n", limit=5), SORT_MAP))
+        assert result["next_cursor"] is not None
+
+    def test_python_sort_last_page_next_cursor_is_none(self):
+        items = [{"n": i} for i in range(3)]
+        db = _mock_db(items=items)
+        svc = ODataService()
+        result = asyncio.run(svc.list_async(db, "PK#t1", _params(sort="n", limit=5), SORT_MAP))
+        assert result["next_cursor"] is None
+
+    def test_python_sort_returns_sorted_slice(self):
+        items = [{"n": 3}, {"n": 1}, {"n": 2}]
+        db = _mock_db(items=items)
+        svc = ODataService()
+        result = asyncio.run(svc.list_async(db, "PK#t1", _params(sort="n", order="asc", limit=2), SORT_MAP))
+        assert [r["n"] for r in result["items"]] == [1, 2]
+
+    def test_python_sort_cursor_resumption(self):
+        real_db = _real_db()
+        all_items = [{"n": i} for i in range(10)]
+        real_db.get_all_async = AsyncMock(return_value=(all_items, None))
+        real_db.batch_get_async = AsyncMock(return_value=[])
+
+        svc = ODataService()
+        # First page
+        result1 = asyncio.run(svc.list_async(real_db, "PK#t1", _params(sort="n", order="asc", limit=4), SORT_MAP))
+        assert [r["n"] for r in result1["items"]] == [0, 1, 2, 3]
+        assert result1["next_cursor"] is not None
+
+        # Second page using returned cursor
+        result2 = asyncio.run(
+            svc.list_async(
+                real_db, "PK#t1",
+                _params(sort="n", order="asc", limit=4, cursor=result1["next_cursor"]),
+                SORT_MAP,
+            )
+        )
+        assert [r["n"] for r in result2["items"]] == [4, 5, 6, 7]
+
+    def test_python_sort_expand_runs_on_page_not_full_set(self):
+        owner_cfg = ExpandConfig(
+            local_key="owner_id", target_pk="USER#t1", remote_key="uid", target_sk_prefix="USER#"
+        )
+        # "score" is NOT in SORT_MAP → triggers Python-sort path
+        all_items = [{"score": i, "owner_id": f"u{i}"} for i in range(10)]
+        db = _mock_db(items=all_items)
+        db.batch_get_async = AsyncMock(return_value=[{"uid": "u0", "email": "a@b.com"}])
+
+        svc = ODataService(expand_config={"owner": owner_cfg})
+        asyncio.run(
+            svc.list_async(db, "PK#t1", _params(sort="score", order="asc", limit=3, expand="owner"), SORT_MAP)
+        )
+        # batch_get_async should be called with at most limit items (3), not all 10
+        call_args = db.batch_get_async.call_args
+        requested_keys = call_args[1].get("keys") or call_args[0][1] if call_args[0] else []
+        assert len(requested_keys) <= 3
+
+    def test_python_sort_invalid_order_raises_value_error(self):
+        db = _mock_db(items=[{"n": 1}])
+        svc = ODataService()
+        with pytest.raises(ValueError):
+            asyncio.run(svc.list_async(db, "PK#t1", _params(sort="n", order="invalid"), SORT_MAP))
+
+
+# ─── Unsorted path ────────────────────────────────────────────────────────────
+
+
+class TestListAsyncUnsortedPath:
+    def test_unsorted_calls_get_all_async_without_lsi_or_fetch_all(self):
+        db = _mock_db()
+        svc = ODataService()
+        asyncio.run(svc.list_async(db, "PK#t1", _params()))
+        call_kwargs = db.get_all_async.call_args[1]
+        assert "lsi" not in call_kwargs
+        assert call_kwargs.get("fetch_all") is not True
+
+    def test_unsorted_when_sort_set_but_no_map(self):
+        db = _mock_db()
+        svc = ODataService()
+        asyncio.run(svc.list_async(db, "PK#t1", _params(sort="name"), sort_field_map=None))
+        call_kwargs = db.get_all_async.call_args[1]
+        assert "lsi" not in call_kwargs
+
+    def test_unsorted_return_shape(self):
+        db = _mock_db(items=[{"id": "1"}], cursor=None)
+        svc = ODataService()
+        result = asyncio.run(svc.list_async(db, "PK#t1", _params()))
+        assert "items" in result
+        assert "next_cursor" in result
+        assert "@odata.nextLink" not in result
+
+
+# ─── Effective limit / cursor precedence ──────────────────────────────────────
+
+
+class TestListAsyncPrecedence:
+    def test_top_takes_precedence_over_limit(self):
+        db = _mock_db()
+        svc = ODataService()
+        asyncio.run(svc.list_async(db, "PK#t1", _params(top=5, limit=25)))
+        call_kwargs = db.get_all_async.call_args[1]
+        assert call_kwargs["limit"] == 5
+
+    def test_skip_token_takes_precedence_over_cursor(self):
+        db = _mock_db()
+        svc = ODataService()
+        asyncio.run(svc.list_async(db, "PK#t1", _params(skip_token="odata-tok", cursor="rest-tok")))
+        call_kwargs = db.get_all_async.call_args[1]
+        assert call_kwargs["cursor"] == "odata-tok"
+
+    def test_filter_forwarded_on_unsorted_path(self):
+        db = _mock_db()
+        svc = ODataService()
+        asyncio.run(svc.list_async(db, "PK#t1", _params(filter="x eq 1")))
+        call_kwargs = db.get_all_async.call_args[1]
+        assert call_kwargs["filter"] == "x eq 1"
+
+    def test_filter_forwarded_on_python_sort_path(self):
+        db = _mock_db()
+        svc = ODataService()
+        asyncio.run(svc.list_async(db, "PK#t1", _params(sort="score", filter="x eq 1"), SORT_MAP))
+        call_kwargs = db.get_all_async.call_args[1]
+        assert call_kwargs["filter"] == "x eq 1"
+
+    def test_filter_forwarded_on_lsi_path(self):
+        db = _mock_db()
+        svc = ODataService()
+        asyncio.run(svc.list_async(db, "PK#t1", _params(sort="name", filter="x eq 1"), SORT_MAP))
+        call_kwargs = db.get_all_async.call_args[1]
+        assert call_kwargs["filter"] == "x eq 1"

--- a/tests/test_list_async.py
+++ b/tests/test_list_async.py
@@ -9,7 +9,6 @@ from dynamo_odata import DynamoDb
 from dynamo_odata.expand import ExpandConfig
 from dynamo_odata.fastapi import ODataQueryParams, ODataService
 
-
 # ─── helpers ──────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_list_async.py
+++ b/tests/test_list_async.py
@@ -150,7 +150,8 @@ class TestListAsyncPythonSortPath:
         # Second page using returned cursor
         result2 = asyncio.run(
             svc.list_async(
-                real_db, "PK#t1",
+                real_db,
+                "PK#t1",
                 _params(sort="n", order="asc", limit=4, cursor=result1["next_cursor"]),
                 SORT_MAP,
             )
@@ -158,18 +159,14 @@ class TestListAsyncPythonSortPath:
         assert [r["n"] for r in result2["items"]] == [4, 5, 6, 7]
 
     def test_python_sort_expand_runs_on_page_not_full_set(self):
-        owner_cfg = ExpandConfig(
-            local_key="owner_id", target_pk="USER#t1", remote_key="uid", target_sk_prefix="USER#"
-        )
+        owner_cfg = ExpandConfig(local_key="owner_id", target_pk="USER#t1", remote_key="uid", target_sk_prefix="USER#")
         # "score" is NOT in SORT_MAP → triggers Python-sort path
         all_items = [{"score": i, "owner_id": f"u{i}"} for i in range(10)]
         db = _mock_db(items=all_items)
         db.batch_get_async = AsyncMock(return_value=[{"uid": "u0", "email": "a@b.com"}])
 
         svc = ODataService(expand_config={"owner": owner_cfg})
-        asyncio.run(
-            svc.list_async(db, "PK#t1", _params(sort="score", order="asc", limit=3, expand="owner"), SORT_MAP)
-        )
+        asyncio.run(svc.list_async(db, "PK#t1", _params(sort="score", order="asc", limit=3, expand="owner"), SORT_MAP))
         # batch_get_async should be called with at most limit items (3), not all 10
         call_args = db.batch_get_async.call_args
         requested_keys = call_args[1].get("keys") or call_args[0][1] if call_args[0] else []

--- a/tests/test_offset_cursor.py
+++ b/tests/test_offset_cursor.py
@@ -1,0 +1,71 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dynamo_odata import DynamoDb
+
+
+def _make_db(cursor_secret: str | None = None) -> DynamoDb:
+    with patch("dynamo_odata.db.boto3") as mock_boto3:
+        mock_resource = MagicMock()
+        mock_table = MagicMock()
+        mock_table.name = "table_dev"
+        mock_resource.Table.return_value = mock_table
+        mock_boto3.resource.return_value = mock_resource
+
+        db = DynamoDb(table_name="table_dev", cursor_secret=cursor_secret)
+        db.table = mock_table
+        db.db = mock_resource
+        return db
+
+
+class TestOffsetCursorEncoding:
+    def test_encode_offset_zero_decodes_correctly(self):
+        db = _make_db()
+        cursor = db.encode_offset_cursor(0)
+        payload = db._decode_cursor(cursor)
+        assert payload == {"__type": "offset", "offset": 0}
+
+    def test_encode_offset_50_decodes_correctly(self):
+        db = _make_db()
+        cursor = db.encode_offset_cursor(50)
+        payload = db._decode_cursor(cursor)
+        assert payload == {"__type": "offset", "offset": 50}
+
+    def test_is_offset_cursor_true_for_offset_payload(self):
+        payload = {"__type": "offset", "offset": 10}
+        assert DynamoDb.is_offset_cursor(payload) is True
+
+    def test_is_offset_cursor_false_for_lek_payload(self):
+        payload = {"PK": "TENANT#1", "SK": "USER#abc"}
+        assert DynamoDb.is_offset_cursor(payload) is False
+
+    def test_is_offset_cursor_false_for_empty_dict(self):
+        assert DynamoDb.is_offset_cursor({}) is False
+
+    def test_decode_offset_cursor_returns_correct_int(self):
+        payload = {"__type": "offset", "offset": 42}
+        assert DynamoDb.decode_offset_cursor(payload) == 42
+
+    def test_round_trip(self):
+        db = _make_db()
+        for n in (0, 1, 25, 100, 9999):
+            cursor = db.encode_offset_cursor(n)
+            payload = db._decode_cursor(cursor)
+            assert DynamoDb.is_offset_cursor(payload)
+            assert DynamoDb.decode_offset_cursor(payload) == n
+
+
+class TestOffsetCursorSigning:
+    def test_signed_offset_cursor_verifies(self):
+        db = _make_db(cursor_secret="s3cr3t")
+        cursor = db.encode_offset_cursor(7)
+        payload = db._decode_cursor(cursor)
+        assert DynamoDb.decode_offset_cursor(payload) == 7
+
+    def test_tampered_offset_cursor_raises(self):
+        db = _make_db(cursor_secret="s3cr3t")
+        cursor = db.encode_offset_cursor(7)
+        tampered = cursor[:-4] + "AAAA"
+        with pytest.raises(ValueError):
+            db._decode_cursor(tampered)

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,0 +1,99 @@
+"""Tests for extended ODataQueryParams."""
+
+from dynamo_odata.fastapi import ODataQueryParams
+
+
+def _make_params(**kwargs) -> ODataQueryParams:
+    p = object.__new__(ODataQueryParams)
+    p.filter = kwargs.get("filter", None)
+    p.select = kwargs.get("select", None)
+    p.expand = kwargs.get("expand", None)
+    p.top = kwargs.get("top", None)
+    p.skip_token = kwargs.get("skip_token", None)
+    p.sort = kwargs.get("sort", None)
+    p.order = kwargs.get("order", "desc")
+    p.limit = kwargs.get("limit", 25)
+    p.cursor = kwargs.get("cursor", None)
+    return p
+
+
+class TestODataQueryParamsDefaults:
+    def test_default_order_is_desc(self):
+        p = _make_params()
+        assert p.order == "desc"
+
+    def test_default_limit_is_25(self):
+        p = _make_params()
+        assert p.limit == 25
+
+    def test_default_sort_is_none(self):
+        p = _make_params()
+        assert p.sort is None
+
+    def test_default_cursor_is_none(self):
+        p = _make_params()
+        assert p.cursor is None
+
+
+class TestODataQueryParamsExistingParams:
+    def test_filter_parses(self):
+        p = _make_params(filter="status eq 'active'")
+        assert p.filter == "status eq 'active'"
+
+    def test_select_parses(self):
+        p = _make_params(select="name,status")
+        assert p.select == "name,status"
+
+    def test_expand_parses(self):
+        p = _make_params(expand="owner")
+        assert p.expand == "owner"
+
+    def test_top_parses(self):
+        p = _make_params(top=10)
+        assert p.top == 10
+
+    def test_skip_token_parses(self):
+        p = _make_params(skip_token="abc123")
+        assert p.skip_token == "abc123"
+
+
+class TestODataQueryParamsNewParams:
+    def test_sort_accepts_string(self):
+        p = _make_params(sort="name")
+        assert p.sort == "name"
+
+    def test_order_accepts_asc(self):
+        p = _make_params(order="asc")
+        assert p.order == "asc"
+
+    def test_limit_accepts_integer(self):
+        p = _make_params(limit=50)
+        assert p.limit == 50
+
+    def test_cursor_accepts_string(self):
+        p = _make_params(cursor="eyJ0eXBlIjogIm9mZnNldCJ9")
+        assert p.cursor == "eyJ0eXBlIjogIm9mZnNldCJ9"
+
+
+class TestODataQueryParamsAllNineAttributes:
+    def test_all_nine_attributes_present(self):
+        p = _make_params(
+            filter="x eq 1",
+            select="a,b",
+            expand="owner",
+            top=5,
+            skip_token="tok",
+            sort="name",
+            order="asc",
+            limit=10,
+            cursor="cur",
+        )
+        assert p.filter == "x eq 1"
+        assert p.select == "a,b"
+        assert p.expand == "owner"
+        assert p.top == 5
+        assert p.skip_token == "tok"
+        assert p.sort == "name"
+        assert p.order == "asc"
+        assert p.limit == 10
+        assert p.cursor == "cur"

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -5,15 +5,15 @@ from dynamo_odata.fastapi import ODataQueryParams
 
 def _make_params(**kwargs) -> ODataQueryParams:
     p = object.__new__(ODataQueryParams)
-    p.filter = kwargs.get("filter", None)
-    p.select = kwargs.get("select", None)
-    p.expand = kwargs.get("expand", None)
-    p.top = kwargs.get("top", None)
-    p.skip_token = kwargs.get("skip_token", None)
-    p.sort = kwargs.get("sort", None)
+    p.filter = kwargs.get("filter")
+    p.select = kwargs.get("select")
+    p.expand = kwargs.get("expand")
+    p.top = kwargs.get("top")
+    p.skip_token = kwargs.get("skip_token")
+    p.sort = kwargs.get("sort")
     p.order = kwargs.get("order", "desc")
     p.limit = kwargs.get("limit", 25)
-    p.cursor = kwargs.get("cursor", None)
+    p.cursor = kwargs.get("cursor")
     return p
 
 

--- a/tests/test_sort_items.py
+++ b/tests/test_sort_items.py
@@ -1,0 +1,78 @@
+import pytest
+
+from dynamo_odata import sort_items
+
+
+class TestSortItemsStrings:
+    def test_ascending_string_case_insensitive(self):
+        items = [{"name": "Cherry"}, {"name": "banana"}, {"name": "Apple"}]
+        result = sort_items(items, "name", "asc")
+        assert [r["name"] for r in result] == ["Apple", "banana", "Cherry"]
+
+    def test_descending_string(self):
+        items = [{"name": "Cherry"}, {"name": "banana"}, {"name": "Apple"}]
+        result = sort_items(items, "name", "desc")
+        assert [r["name"] for r in result] == ["Cherry", "banana", "Apple"]
+
+
+class TestSortItemsNumeric:
+    def test_ascending_numeric(self):
+        items = [{"score": 30}, {"score": 10}, {"score": 20}]
+        result = sort_items(items, "score", "asc")
+        assert [r["score"] for r in result] == [10, 20, 30]
+
+    def test_descending_numeric(self):
+        items = [{"score": 30}, {"score": 10}, {"score": 20}]
+        result = sort_items(items, "score", "desc")
+        assert [r["score"] for r in result] == [30, 20, 10]
+
+
+class TestSortItemsMissingField:
+    def test_missing_field_sorts_last_asc(self):
+        items = [{"name": "B"}, {}, {"name": "A"}]
+        result = sort_items(items, "name", "asc")
+        assert result[0]["name"] == "A"
+        assert result[1]["name"] == "B"
+        assert "name" not in result[2]
+
+    def test_missing_field_sorts_last_desc(self):
+        items = [{"name": "B"}, {}, {"name": "A"}]
+        result = sort_items(items, "name", "desc")
+        assert result[0]["name"] == "B"
+        assert result[1]["name"] == "A"
+        assert "name" not in result[2]
+
+    def test_mixed_present_and_missing(self):
+        items = [{"v": 5}, {}, {"v": 1}, {}, {"v": 3}]
+        result = sort_items(items, "v", "asc")
+        present = [r for r in result if "v" in r]
+        missing = [r for r in result if "v" not in r]
+        assert [r["v"] for r in present] == [1, 3, 5]
+        assert result[-1] not in present or True
+        assert len(missing) == 2
+        assert result[-2] in missing
+        assert result[-1] in missing
+
+
+class TestSortItemsBehavior:
+    def test_does_not_mutate_input(self):
+        items = [{"name": "B"}, {"name": "A"}]
+        original_first = items[0]["name"]
+        sort_items(items, "name", "asc")
+        assert items[0]["name"] == original_first
+
+    def test_default_direction_is_asc(self):
+        items = [{"n": 3}, {"n": 1}, {"n": 2}]
+        result = sort_items(items, "n")
+        assert [r["n"] for r in result] == [1, 2, 3]
+
+    def test_invalid_direction_raises_value_error(self):
+        with pytest.raises(ValueError, match="direction must be 'asc' or 'desc'"):
+            sort_items([{"n": 1}], "n", "random")
+
+    def test_invalid_direction_includes_bad_value(self):
+        with pytest.raises(ValueError, match="random"):
+            sort_items([{"n": 1}], "n", "random")
+
+    def test_empty_list_returns_empty(self):
+        assert sort_items([], "name") == []


### PR DESCRIPTION
Closes #29

## Summary

- **Offset cursor helpers** (`encode_offset_cursor`, `is_offset_cursor`, `decode_offset_cursor`) on `DynamoDb` — opaque, HMAC-signable cursors for Python-sorted pagination
- **`sort_items` utility** in `dynamo_odata.utils` — standalone case-insensitive sort with missing-field-last semantics, exported from `dynamo_odata`
- **Extended `ODataQueryParams`** — adds `sort`, `order` (default `"desc"`), `limit` (default 25), and `cursor` alongside existing OData params; no breaking changes
- **`ODataService.list_async`** — routes to LSI pagination, Python-sort + offset-cursor pagination, or unsorted query based on sort field and a caller-supplied `sort_field_map`; returns `{"items": [...], "next_cursor": str | None}`

## Test plan

- [ ] `tests/test_offset_cursor.py` — 9 tests: encode/decode round-trips, HMAC signing and tamper detection
- [ ] `tests/test_sort_items.py` — 12 tests: asc/desc strings and numbers, missing-field-last, no mutation, invalid direction error
- [ ] `tests/test_params.py` — 14 tests: all 9 attributes, defaults, backward compatibility
- [ ] `tests/test_list_async.py` — 20 tests: all three routing paths, cursor resumption, expand-on-slice, precedence rules, return shape
- [ ] Full suite: 305 passed