### PR TITLE
fix(async): self-heal stale shared aioboto3 resource in long-running processes (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-05-29
+
+### Fixed
+
+- **Self-heal a stale shared async resource** — in a long-running process that reuses one
+  app-wide aioboto3 DynamoDB *resource* (set via `async with DynamoDb(...)` or injected by the
+  host app), the shared resource's session/connection can go stale after hours of uptime. The
+  next resource-based async call then failed **client-side before reaching DynamoDB** (no DynamoDB
+  error recorded), and botocore retries could not recover it — while fresh-client paths
+  (`transact_write_async`, sync calls) kept working. All async operations now run through a
+  `_run_async` helper that, on a client-side transport error (`ConnectionError`/`HTTPClientError`,
+  aiohttp `ClientError`, or a closed-client/closed-loop `RuntimeError`) while a shared resource is
+  in use, discards the stale shared resource and retries the operation **once** on a freshly
+  created per-call resource. Non-connection errors (e.g. `ClientError`) and per-call resources are
+  never retried. Paginating reads reset their accumulators on retry, so recovery never drops or
+  duplicates items. No public API change. ([#35](https://github.com/one-table-labs/dynamo-odata/issues/35))
+
+---
+
 ## [0.8.0] - 2026-05-02
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dynamo-odata"
-version = "0.8.0"
+version = "0.8.1"
 description = "OData filter and projection helpers for AWS DynamoDB"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/dynamo_odata/db.py
+++ b/src/dynamo_odata/db.py
@@ -662,25 +662,28 @@ class DynamoDb:
             params["ExclusiveStartKey"] = start_key
 
         async def _op(resource: Any) -> tuple[list[dict[str, Any]], str | None]:
+            # Local copy so a self-heal retry (which re-runs _op) starts from the
+            # original params, not a mutated mid-pagination state.
+            query_params = dict(params)
             table = await resource.Table(self.table.name)
             items: list[dict[str, Any]] = []
 
             if fetch_all:
-                params["Limit"] = 500
+                query_params["Limit"] = 500
                 last_key: Any = True
                 while last_key is not None:
-                    result = await table.query(**params)
+                    result = await table.query(**query_params)
                     self.add_consumed_capacity(result.get("ConsumedCapacity"))
                     items.extend(result.get("Items", []))
                     last_key = result.get("LastEvaluatedKey")
                     if last_key:
-                        params["ExclusiveStartKey"] = last_key
+                        query_params["ExclusiveStartKey"] = last_key
                     else:
-                        params.pop("ExclusiveStartKey", None)
+                        query_params.pop("ExclusiveStartKey", None)
                 return items, None
 
-            params["Limit"] = limit
-            result = await table.query(**params)
+            query_params["Limit"] = limit
+            result = await table.query(**query_params)
             self.add_consumed_capacity(result.get("ConsumedCapacity"))
             items = result.get("Items", [])
             next_cursor: str | None = None

--- a/src/dynamo_odata/db.py
+++ b/src/dynamo_odata/db.py
@@ -520,15 +520,15 @@ class DynamoDb:
                     table_spec["ExpressionAttributeNames"] = expr_attr_names
 
         batch_chunk = 100
-        all_items: list[dict[str, Any]] = []
-        pending_keys = keys
-        retry_delay = 0.0
 
-        async with self._async_resource() as resource:
-            while pending_keys:
-                chunk, pending_keys = (
-                    pending_keys[:batch_chunk],
-                    pending_keys[batch_chunk:],
+        async def _op(resource: Any) -> list[dict[str, Any]]:
+            op_items: list[dict[str, Any]] = []
+            op_pending = list(keys)
+            op_retry_delay = 0.0
+            while op_pending:
+                chunk, op_pending = (
+                    op_pending[:batch_chunk],
+                    op_pending[batch_chunk:],
                 )
                 request_items: dict[str, Any] = {table_name: {**table_spec, "Keys": chunk}}
                 response = await resource.batch_get_item(
@@ -536,16 +536,18 @@ class DynamoDb:
                     ReturnConsumedCapacity="TOTAL",
                 )
                 self.add_consumed_capacity(response.get("ConsumedCapacity"))
-                all_items.extend(response.get("Responses", {}).get(table_name, []))
+                op_items.extend(response.get("Responses", {}).get(table_name, []))
 
                 unprocessed = response.get("UnprocessedKeys", {})
                 if unprocessed and table_name in unprocessed:
-                    retry_delay = min(retry_delay * 2 if retry_delay else 0.05, 1.0)
-                    await asyncio.sleep(retry_delay)
-                    pending_keys = unprocessed[table_name]["Keys"] + pending_keys
+                    op_retry_delay = min(op_retry_delay * 2 if op_retry_delay else 0.05, 1.0)
+                    await asyncio.sleep(op_retry_delay)
+                    op_pending = unprocessed[table_name]["Keys"] + op_pending
                 else:
-                    retry_delay = 0.0
+                    op_retry_delay = 0.0
+            return op_items
 
+        all_items = await self._run_async(_op)
         if item_only:
             return all_items
         return {"Responses": {table_name: all_items}}
@@ -578,9 +580,11 @@ class DynamoDb:
                 if expr_attr_names:
                     params["ExpressionAttributeNames"] = expr_attr_names
 
-        async with self._async_resource() as resource:
+        async def _op(resource: Any) -> dict[str, Any]:
             table = await resource.Table(self.table.name)
-            response = await table.get_item(**params)
+            return await table.get_item(**params)
+
+        response = await self._run_async(_op)
         self.add_consumed_capacity(response.get("ConsumedCapacity"))
         item = response.get("Item")
         if item is None:
@@ -657,9 +661,9 @@ class DynamoDb:
         if start_key is not None:
             params["ExclusiveStartKey"] = start_key
 
-        items: list[dict[str, Any]] = []
-        async with self._async_resource() as resource:
+        async def _op(resource: Any) -> tuple[list[dict[str, Any]], str | None]:
             table = await resource.Table(self.table.name)
+            items: list[dict[str, Any]] = []
 
             if fetch_all:
                 params["Limit"] = 500
@@ -683,6 +687,8 @@ class DynamoDb:
             if last_evaluated := result.get("LastEvaluatedKey"):
                 next_cursor = self._encode_cursor(last_evaluated)
             return items, next_cursor
+
+        return await self._run_async(_op)
 
     def put(
         self,
@@ -800,9 +806,11 @@ class DynamoDb:
         if expression_attribute_names:
             params["ExpressionAttributeNames"] = expression_attribute_names
 
-        async with self._async_resource() as resource:
+        async def _op(resource: Any) -> dict[str, Any]:
             table = await resource.Table(self.table.name)
-            response = await table.update_item(**params)
+            return await table.update_item(**params)
+
+        response = await self._run_async(_op)
         self.add_consumed_capacity(response.get("ConsumedCapacity"))
         if item_only and "Attributes" in response:
             return response["Attributes"]
@@ -837,9 +845,12 @@ class DynamoDb:
         body = self._convert_to_decimal(dict(item))
         body = self._strip_key_attributes(body)
         full_item = {self.partition_key_name: pk, self.sort_key_name: sk, **body}
-        async with self._async_resource() as resource:
+
+        async def _op(resource: Any) -> None:
             table = await resource.Table(self.table.name)
             await table.put_item(Item=full_item, ReturnConsumedCapacity="TOTAL")
+
+        await self._run_async(_op)
 
     def create_item(self, pk: str, sk: str, item: dict[str, Any]) -> None:
         """
@@ -878,13 +889,16 @@ class DynamoDb:
         body = self._convert_to_decimal(dict(item))
         body = self._strip_key_attributes(body)
         full_item = {self.partition_key_name: pk, self.sort_key_name: sk, **body}
-        async with self._async_resource() as resource:
+
+        async def _op(resource: Any) -> None:
             table = await resource.Table(self.table.name)
             await table.put_item(
                 Item=full_item,
                 ConditionExpression=Attr(self.partition_key_name).not_exists(),
                 ReturnConsumedCapacity="TOTAL",
             )
+
+        await self._run_async(_op)
 
     def update_item(self, pk: str, sk: str, updates: dict[str, Any]) -> dict[str, Any]:
         """
@@ -989,9 +1003,10 @@ class DynamoDb:
     async def _batch_purge_keys_async(self, keys: list[dict[str, str]]) -> None:
         """Async version of _batch_purge_keys."""
         table_name = self.table.name
-        pending = list(keys)
-        retry_delay = 0.0
-        async with self._async_resource() as resource:
+
+        async def _op(resource: Any) -> None:
+            pending = list(keys)
+            retry_delay = 0.0
             while pending:
                 chunk, pending = pending[:25], pending[25:]
                 request_items: dict[str, Any] = {table_name: [{"DeleteRequest": {"Key": k}} for k in chunk]}
@@ -1007,6 +1022,8 @@ class DynamoDb:
                     pending = [req["DeleteRequest"]["Key"] for req in unprocessed] + pending
                 else:
                     retry_delay = 0.0
+
+        await self._run_async(_op)
 
     def delete(
         self,
@@ -1114,13 +1131,15 @@ class DynamoDb:
                     new_record[key] = value
             await self.put_async(pk=pk, sk=new_sk, data=new_record)
 
-        async with self._async_resource() as resource:
+        async def _op(resource: Any) -> dict[str, Any]:
             table = await resource.Table(self.table.name)
-            response = await table.delete_item(
+            return await table.delete_item(
                 Key=self._key_dict(pk, sk),
                 ReturnValues="ALL_OLD",
                 ReturnConsumedCapacity="TOTAL",
             )
+
+        response = await self._run_async(_op)
         self.add_consumed_capacity(response.get("ConsumedCapacity"))
         return response
 
@@ -1185,13 +1204,16 @@ class DynamoDb:
             raise ValueError("Either sk or sk_begins_with must be provided")
 
         if is_purge:
-            async with self._async_resource() as resource:
+
+            async def _op(resource: Any) -> dict[str, Any]:
                 table = await resource.Table(self.table.name)
-                response = await table.delete_item(
+                return await table.delete_item(
                     Key=self._key_dict(pk, sk),
                     ReturnValues="ALL_OLD",
                     ReturnConsumedCapacity="TOTAL",
                 )
+
+            response = await self._run_async(_op)
             self.add_consumed_capacity(response.get("ConsumedCapacity"))
             return response
 
@@ -1414,9 +1436,11 @@ class DynamoDb:
         if cursor is not None:
             params["ExclusiveStartKey"] = self._decode_cursor(cursor)
 
-        async with self._async_resource() as resource:
+        async def _op(resource: Any) -> dict[str, Any]:
             table = await resource.Table(self.table.name)
-            response = await table.query(**params)
+            return await table.query(**params)
+
+        response = await self._run_async(_op)
         self.add_consumed_capacity(response.get("ConsumedCapacity"))
         items = response.get("Items", [])
 
@@ -1550,9 +1574,11 @@ class DynamoDb:
         if skip_token is not None:
             params["ExclusiveStartKey"] = skip_token
 
-        async with self._async_resource() as resource:
+        async def _op(resource: Any) -> dict[str, Any]:
             table = await resource.Table(self.table.name)
-            response = await table.scan(**params)
+            return await table.scan(**params)
+
+        response = await self._run_async(_op)
         self.add_consumed_capacity(response.get("ConsumedCapacity"))
 
         result: dict[str, Any] = {

--- a/src/dynamo_odata/db.py
+++ b/src/dynamo_odata/db.py
@@ -5,20 +5,51 @@ import base64
 import hashlib
 import hmac
 import json
+import logging
 import time
+from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import replace
 from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
-from typing import Any
+from typing import Any, TypeVar
 
 import boto3
 from boto3.dynamodb.conditions import Attr, ConditionBase, Key
+from botocore.exceptions import ConnectionError as BotoConnectionError
+from botocore.exceptions import HTTPClientError
 
 from .dynamo_filter import build_filter
 from .guardrails import FilterPolicy, PartitionKeyGuard
 from .projection import build_projection
 from .schema import KeySchema
+
+logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
+
+
+def _is_stale_connection_error(exc: BaseException) -> bool:
+    """True if ``exc`` indicates the (shared) async resource's connection/session
+    is dead — i.e. the request never reached DynamoDB and is safe to retry once
+    on a fresh resource.
+
+    Covers botocore transport errors — ``ConnectionError`` (and its
+    ``EndpointConnectionError`` …) plus ``HTTPClientError`` (and its
+    ``ConnectionClosedError`` / ``ReadTimeoutError`` …) — aiohttp client errors,
+    and the ``RuntimeError("... is closed")`` / ``"Event loop is closed"`` family
+    raised by aiobotocore/aiohttp when a long-lived client has been torn down.
+    """
+    if isinstance(exc, (BotoConnectionError, HTTPClientError)):
+        return True
+    try:  # aiohttp is a transitive dep via aioboto3; import lazily.
+        import aiohttp
+
+        if isinstance(exc, aiohttp.ClientError):
+            return True
+    except ImportError:  # pragma: no cover - aiohttp always present with aioboto3
+        pass
+    return isinstance(exc, RuntimeError) and "closed" in str(exc).lower()
 
 
 def _get_aioboto3_session(async_session: Any = None) -> Any:
@@ -151,6 +182,37 @@ class DynamoDb:
             session = self._get_aioboto3_session()
             async with session.resource("dynamodb", **self._async_resource_kwargs()) as resource:
                 yield resource
+
+    async def _run_async(self, op: Callable[[Any], Awaitable[_T]]) -> _T:
+        """Run ``op(resource)`` against a DynamoDB async resource, self-healing a
+        stale shared resource.
+
+        When a long-lived shared resource is in use (set via ``__aenter__`` or
+        injected by the host app) its session/connection can go stale in a
+        long-running process; the call then fails client-side before reaching
+        DynamoDB. On such a connection error we discard the stale shared resource
+        and retry the operation once on a freshly-created per-call resource.
+
+        Operations that already use a fresh per-call resource, and non-connection
+        errors (e.g. ``ClientError``), are never retried — they propagate.
+        """
+        try:
+            async with self._async_resource() as resource:
+                return await op(resource)
+        except Exception as exc:
+            if self._shared_resource is None or not _is_stale_connection_error(exc):
+                raise
+            logger.warning(
+                "dynamo-odata: shared async DynamoDB resource appears stale (%s); "
+                "discarding it and retrying once on a fresh resource",
+                type(exc).__name__,
+            )
+            # Stop using the dead shared resource on this instance.
+            self._shared_resource = None
+            self._resource_cm = None
+            session = self._get_aioboto3_session()
+            async with session.resource("dynamodb", **self._async_resource_kwargs()) as resource:
+                return await op(resource)
 
     async def __aenter__(self) -> DynamoDb:
         session = self._get_aioboto3_session()
@@ -894,9 +956,12 @@ class DynamoDb:
             "ReturnValues": "ALL_NEW",
             "ReturnConsumedCapacity": "TOTAL",
         }
-        async with self._async_resource() as resource:
+
+        async def _op(resource: Any) -> dict[str, Any]:
             table = await resource.Table(self.table.name)
-            response = await table.update_item(**params)
+            return await table.update_item(**params)
+
+        response = await self._run_async(_op)
         self.add_consumed_capacity(response.get("ConsumedCapacity"))
         return response.get("Attributes", {})
 

--- a/tests/test_async_resource_heal.py
+++ b/tests/test_async_resource_heal.py
@@ -101,3 +101,33 @@ def test_update_item_async_connection_error_without_shared_resource_propagates()
         mock_session.return_value.resource.return_value = ctx
         with pytest.raises(ConnectionClosedError):
             asyncio.run(db.update_item_async("TENANT#t1#USER", "1#u1", {"name": "x"}))
+
+
+def test_get_all_async_self_heals_on_stale_shared_resource():
+    """A paginating read recovers via a fresh resource with a clean accumulator."""
+    db = _make_db()
+
+    # Stale shared resource: query raises a connection error (request never lands).
+    stale_table = AsyncMock()
+    stale_table.query.side_effect = ConnectionClosedError(endpoint_url="https://dynamodb.us-east-1.amazonaws.com")
+    stale_resource = AsyncMock()
+    stale_resource.Table.return_value = stale_table
+    db._shared_resource = stale_resource
+
+    # Fresh resource returns one full page (no LastEvaluatedKey).
+    fresh_table = AsyncMock()
+    fresh_table.query.return_value = {"Items": [{"SK": "1#a"}, {"SK": "1#b"}]}
+    fresh_resource = AsyncMock()
+    fresh_resource.Table.return_value = fresh_table
+    fresh_ctx = AsyncMock()
+    fresh_ctx.__aenter__.return_value = fresh_resource
+    fresh_ctx.__aexit__.return_value = False
+
+    with patch("dynamo_odata.db._get_aioboto3_session") as mock_session:
+        mock_session.return_value.resource.return_value = fresh_ctx
+        items, next_cursor = asyncio.run(db.get_all_async("TENANT#t1#USER", fetch_all=True))
+
+    assert items == [{"SK": "1#a"}, {"SK": "1#b"}]  # no loss, no duplication
+    assert next_cursor is None
+    assert db._shared_resource is None
+    stale_table.query.assert_awaited_once()

--- a/tests/test_async_resource_heal.py
+++ b/tests/test_async_resource_heal.py
@@ -1,0 +1,103 @@
+"""Self-healing of a stale long-lived shared async resource (issue #35).
+
+A long-running process that reuses one app-wide aioboto3 DynamoDB *resource*
+hits a client-side connection error after the shared resource's session/
+connection goes stale (no request reaches DynamoDB). The repo should discard
+the stale shared resource and retry once on a freshly-created resource.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError, ConnectionClosedError
+
+from dynamo_odata import UPPERCASE_KEY_SCHEMA, DynamoDb
+
+
+def _make_db() -> DynamoDb:
+    with patch("dynamo_odata.db.boto3") as mock_boto3:
+        mock_resource = MagicMock()
+        mock_table = MagicMock()
+        mock_table.name = "table_dev"
+        mock_resource.Table.return_value = mock_table
+        mock_boto3.resource.return_value = mock_resource
+        db = DynamoDb(table_name="table_dev", key_schema=UPPERCASE_KEY_SCHEMA)
+        db.table = mock_table
+        db.db = mock_resource
+        return db
+
+
+def _fresh_ctx(response: dict):
+    """An async-CM resource (as returned by session.resource(...)) that works."""
+    table = AsyncMock()
+    table.update_item.return_value = response
+    resource = AsyncMock()
+    resource.Table.return_value = table
+    ctx = AsyncMock()
+    ctx.__aenter__.return_value = resource
+    ctx.__aexit__.return_value = False
+    return ctx
+
+
+def _stale_shared_resource(exc: BaseException):
+    """A shared resource whose table op raises a connection error (stale session)."""
+    table = AsyncMock()
+    table.update_item.side_effect = exc
+    resource = AsyncMock()
+    resource.Table.return_value = table
+    return resource, table
+
+
+def test_update_item_async_self_heals_stale_shared_resource():
+    db = _make_db()
+    stale_resource, stale_table = _stale_shared_resource(
+        ConnectionClosedError(endpoint_url="https://dynamodb.us-east-1.amazonaws.com")
+    )
+    db._shared_resource = stale_resource
+
+    fresh = _fresh_ctx({"Attributes": {"name": "Alice", "status": "active"}})
+    with patch("dynamo_odata.db._get_aioboto3_session") as mock_session:
+        mock_session.return_value.resource.return_value = fresh
+        result = asyncio.run(db.update_item_async("TENANT#t1#USER", "1#u1", {"name": "Alice", "status": "active"}))
+
+    # Recovered via a fresh resource …
+    assert result == {"name": "Alice", "status": "active"}
+    # … the stale shared resource was tried once …
+    stale_table.update_item.assert_awaited_once()
+    # … and discarded so subsequent calls don't keep hitting it.
+    assert db._shared_resource is None
+
+
+def test_update_item_async_does_not_retry_non_connection_errors():
+    """A real DynamoDB error (ClientError) must propagate, not trigger a heal-retry."""
+    db = _make_db()
+    client_err = ClientError({"Error": {"Code": "ValidationException", "Message": "bad"}}, "UpdateItem")
+    stale_resource, _ = _stale_shared_resource(client_err)
+    db._shared_resource = stale_resource
+
+    fresh = _fresh_ctx({"Attributes": {"name": "ShouldNotBeUsed"}})
+    with patch("dynamo_odata.db._get_aioboto3_session") as mock_session:
+        mock_session.return_value.resource.return_value = fresh
+        with pytest.raises(ClientError):
+            asyncio.run(db.update_item_async("TENANT#t1#USER", "1#u1", {"name": "x"}))
+
+    # Shared resource left intact (not a staleness signal) and no fresh retry happened.
+    assert db._shared_resource is stale_resource
+    fresh.__aenter__.assert_not_awaited()
+
+
+def test_update_item_async_connection_error_without_shared_resource_propagates():
+    """When already on a per-call resource, a connection error has nothing to heal."""
+    db = _make_db()
+    assert db._shared_resource is None
+
+    ctx = AsyncMock()
+    ctx.__aenter__.return_value.Table.return_value.update_item.side_effect = ConnectionClosedError(
+        endpoint_url="https://dynamodb.us-east-1.amazonaws.com"
+    )
+    ctx.__aexit__.return_value = False
+    with patch("dynamo_odata.db._get_aioboto3_session") as mock_session:
+        mock_session.return_value.resource.return_value = ctx
+        with pytest.raises(ConnectionClosedError):
+            asyncio.run(db.update_item_async("TENANT#t1#USER", "1#u1", {"name": "x"}))


### PR DESCRIPTION
Closes #35

## Problem

In a long-running process that reuses one app-wide aioboto3 DynamoDB **resource** (set via `async with DynamoDb(...)` or injected by the host app), the shared resource's session/connection goes stale after hours of uptime. The next resource-based async call (`update_item_async`, `get_async`, …) then fails **client-side before reaching DynamoDB** — no DynamoDB error is recorded — and botocore retries can't recover it, while fresh-client paths (`transact_write_async`, sync calls) keep working. This was the root cause of a downstream production incident.

## Fix (self-heal, no API change)

- New `_run_async(op)` helper: runs `await op(resource)` against an async resource and, on a **client-side transport error while a shared resource is in use**, discards the stale shared resource and retries the operation **once** on a freshly-created per-call resource.
- `_is_stale_connection_error(exc)` recognizes the transport-error families: botocore `ConnectionError` + `HTTPClientError` (covers `ConnectionClosedError`, `EndpointConnectionError`, …), aiohttp `ClientError`, and closed-client/closed-loop `RuntimeError`s.
- Non-connection errors (e.g. `ClientError`/`ValidationException`) and operations already on a per-call resource are **never** retried — they propagate unchanged.
- All 12 async resource-using methods route through the helper (`get/get_all/batch_get/put/put_item/create_item/update_item/delete/soft_delete/query_gsi/scan_all_paginated/_batch_purge_keys`). `transact_write_async` already builds a fresh client per call and is untouched.
- Paginating reads reset their accumulators inside the retried op (and `get_all_async`'s fetch-all loop works on a local copy of params), so a retry never drops or duplicates items.

## Tests

- New `tests/test_async_resource_heal.py`: stale-shared-resource self-heals (write + paginating read); non-connection errors propagate without retry; per-call connection errors propagate; the stale shared resource is discarded after one failed attempt.
- Full suite green: **309 passed**; `ruff` + `mypy` clean.

## Release

Bumps to **0.8.1** (CHANGELOG updated). Per the release process, tag `v0.8.1` on `main` after merge to trigger the PyPI publish workflow. Downstream (PathfindEHR) will then bump `dynamo-odata>=0.8.1`.
