### PR TITLE
fix(pagination): reject non-dict skip_token at the call boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2026-06-15
+
+### Fixed
+
+- **Reject a non-dict `skip_token` at the call boundary** — `get_all` / `get_all_async`
+  accept either an opaque `cursor` string or a raw `LastEvaluatedKey` `skip_token` dict
+  (the latter deprecated). A caller that mistakenly passed a base64 **cursor string** into
+  `skip_token` got no error at the call site; the string flowed verbatim to boto3 as
+  `ExclusiveStartKey`, which only then rejected it (must be a mapping), 500ing at request
+  time. Both methods now validate `skip_token` is a `dict` (or `None`) up front and raise a
+  clear `TypeError` pointing the caller at `cursor`. Valid `dict` skip-tokens and all
+  `cursor`-based pagination are unaffected. Start-key resolution for both the sync and async
+  paths is consolidated in one `_resolve_start_key` helper. No other public API change.
+
 ## [0.8.1] - 2026-05-29
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dynamo-odata"
-version = "0.8.1"
+version = "0.8.2"
 description = "OData filter and projection helpers for AWS DynamoDB"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/dynamo_odata/db.py
+++ b/src/dynamo_odata/db.py
@@ -149,6 +149,33 @@ class DynamoDb:
             return json.loads(base64.b64decode(payload.encode()).decode())
         return json.loads(base64.b64decode(cursor.encode()).decode())
 
+    def _resolve_start_key(
+        self, cursor: str | None, skip_token: dict[str, Any] | None
+    ) -> dict[str, Any] | None:
+        """Resolve the ``ExclusiveStartKey`` for a paginated query.
+
+        ``cursor`` is an opaque (optionally signed) base64 string decoded into a
+        ``LastEvaluatedKey``.  ``skip_token`` (deprecated) is a raw
+        ``LastEvaluatedKey`` dict forwarded verbatim.
+
+        ``skip_token`` must be a ``dict`` (or ``None``).  A caller that passes a
+        base64 cursor string into ``skip_token`` would otherwise sail past the
+        call site and only fail deep in boto3 (``ExclusiveStartKey`` must be a
+        mapping), 500ing at request time.  Reject it here with a clear
+        ``TypeError`` so the mistake surfaces at the call boundary.
+        """
+        if cursor is not None:
+            return self._decode_cursor(cursor)
+        if skip_token is not None:
+            if not isinstance(skip_token, dict):
+                raise TypeError(
+                    "skip_token must be a LastEvaluatedKey dict (or None); got "
+                    f"{type(skip_token).__name__}. Pass an opaque cursor string via "
+                    "the 'cursor' argument instead."
+                )
+            return skip_token
+        return None
+
     def encode_offset_cursor(self, offset: int) -> str:
         """Return an opaque cursor representing a Python-side pagination offset."""
         return self._encode_cursor({"__type": "offset", "offset": offset})
@@ -365,6 +392,11 @@ class DynamoDb:
             cursor: Opaque base64 pagination cursor from a previous call.  Mutually
                 exclusive with ``skip_token``.
             skip_token: Raw ``LastEvaluatedKey`` dict (deprecated — use ``cursor``).
+                Must be a ``dict`` or ``None``; passing anything else (e.g. a
+                base64 cursor string) raises ``TypeError`` at the call boundary.
+
+        Raises:
+            TypeError: If ``skip_token`` is neither a ``dict`` nor ``None``.
         """
         self._validate_partition_key(pk)
         del next_link
@@ -410,11 +442,7 @@ class DynamoDb:
                 if expr_attr_names:
                     params["ExpressionAttributeNames"] = expr_attr_names
 
-        start_key: dict[str, Any] | None = None
-        if cursor is not None:
-            start_key = self._decode_cursor(cursor)
-        elif skip_token is not None:
-            start_key = skip_token
+        start_key = self._resolve_start_key(cursor, skip_token)
         if start_key is not None:
             params["ExclusiveStartKey"] = start_key
 
@@ -653,11 +681,7 @@ class DynamoDb:
                 if expr_attr_names:
                     params["ExpressionAttributeNames"] = expr_attr_names
 
-        start_key: dict[str, Any] | None = None
-        if cursor is not None:
-            start_key = self._decode_cursor(cursor)
-        elif skip_token is not None:
-            start_key = skip_token
+        start_key = self._resolve_start_key(cursor, skip_token)
         if start_key is not None:
             params["ExclusiveStartKey"] = start_key
 

--- a/src/dynamo_odata/db.py
+++ b/src/dynamo_odata/db.py
@@ -149,9 +149,7 @@ class DynamoDb:
             return json.loads(base64.b64decode(payload.encode()).decode())
         return json.loads(base64.b64decode(cursor.encode()).decode())
 
-    def _resolve_start_key(
-        self, cursor: str | None, skip_token: dict[str, Any] | None
-    ) -> dict[str, Any] | None:
+    def _resolve_start_key(self, cursor: str | None, skip_token: dict[str, Any] | None) -> dict[str, Any] | None:
         """Resolve the ``ExclusiveStartKey`` for a paginated query.
 
         ``cursor`` is an opaque (optionally signed) base64 string decoded into a

--- a/tests/test_get_all.py
+++ b/tests/test_get_all.py
@@ -174,3 +174,84 @@ class TestGetAllAsync:
 
         assert items == [{"pk": "a"}]
         assert cursor is not None
+
+
+class TestSkipTokenValidation:
+    """``skip_token`` is a raw LastEvaluatedKey dict. A caller that passes a
+    base64 cursor string into it must fail fast at the call boundary with a
+    clear ``TypeError`` rather than letting the string flow to boto3 and 500
+    at request time."""
+
+    def test_get_all_rejects_string_skip_token(self):
+        db = _make_db()
+
+        try:
+            db.get_all("user::t1", skip_token="eyJwayI6ICJhIn0=")  # noqa: S106
+            raise AssertionError("expected TypeError")
+        except TypeError as exc:
+            assert "skip_token" in str(exc)
+
+        db.table.query.assert_not_called()
+
+    def test_get_all_rejects_non_dict_skip_token(self):
+        db = _make_db()
+
+        for bad in ([{"pk": "a"}], 42, ("pk", "a")):
+            try:
+                db.get_all("user::t1", skip_token=bad)
+                raise AssertionError(f"expected TypeError for {bad!r}")
+            except TypeError:
+                pass
+
+        db.table.query.assert_not_called()
+
+    def test_get_all_accepts_dict_skip_token(self):
+        db = _make_db()
+        db.table.query.return_value = {"Items": [{"pk": "b"}], "Count": 1}
+
+        items, _ = db.get_all("user::t1", skip_token={"pk": "a", "sk": "1#x"})
+
+        assert items == [{"pk": "b"}]
+        assert db.table.query.call_args.kwargs["ExclusiveStartKey"] == {"pk": "a", "sk": "1#x"}
+
+    def test_get_all_async_rejects_string_skip_token(self):
+        db = _make_db()
+        ctx = self._ctx_never_queries()
+
+        with patch("dynamo_odata.db._get_aioboto3_session") as mock_session:
+            mock_session.return_value.resource.return_value = ctx
+            try:
+                asyncio.run(db.get_all_async("user::t1", skip_token="eyJwayI6ICJhIn0="))  # noqa: S106
+                raise AssertionError("expected TypeError")
+            except TypeError as exc:
+                assert "skip_token" in str(exc)
+
+    def test_get_all_async_accepts_dict_skip_token(self):
+        db = _make_db()
+        mock_table = AsyncMock()
+        mock_table.query.return_value = {"Items": [{"pk": "b"}], "Count": 1}
+        mock_resource = AsyncMock()
+        mock_resource.Table.return_value = mock_table
+        ctx = AsyncMock()
+        ctx.__aenter__.return_value = mock_resource
+        ctx.__aexit__.return_value = False
+
+        with patch("dynamo_odata.db._get_aioboto3_session") as mock_session:
+            mock_session.return_value.resource.return_value = ctx
+            items, _ = asyncio.run(db.get_all_async("user::t1", skip_token={"pk": "a", "sk": "1#x"}))
+
+        assert items == [{"pk": "b"}]
+        assert mock_table.query.call_args.kwargs["ExclusiveStartKey"] == {"pk": "a", "sk": "1#x"}
+
+    @staticmethod
+    def _ctx_never_queries() -> AsyncMock:
+        """A resource context whose table would raise if queried — proves the
+        TypeError fires before any DynamoDB call."""
+        mock_table = AsyncMock()
+        mock_table.query.side_effect = AssertionError("query must not be called")
+        mock_resource = AsyncMock()
+        mock_resource.Table.return_value = mock_table
+        ctx = AsyncMock()
+        ctx.__aenter__.return_value = mock_resource
+        ctx.__aexit__.return_value = False
+        return ctx

--- a/uv.lock
+++ b/uv.lock
@@ -314,7 +314,7 @@ wheels = [
 
 [[package]]
 name = "dynamo-odata"
-version = "0.8.1"
+version = "0.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/uv.lock
+++ b/uv.lock
@@ -314,7 +314,7 @@ wheels = [
 
 [[package]]
 name = "dynamo-odata"
-version = "0.7.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

`get_all` / `get_all_async` accept either an opaque `cursor` string or a raw `LastEvaluatedKey` `skip_token` dict (the latter deprecated). A caller that mistakenly passed a base64 **cursor string** into `skip_token` got no error at the call site — the string flowed verbatim to boto3 as `ExclusiveStartKey`, which only then rejected it (must be a mapping), 500ing at request time.

Both methods now validate `skip_token` is a `dict` (or `None`) up front and raise a clear `TypeError` pointing the caller at `cursor`. Start-key resolution for the sync and async paths is consolidated into one `_resolve_start_key` helper.

## Behavior

- Passing a base64 string (or any non-dict) into `skip_token` → `TypeError` **before** any DynamoDB call.
- Valid `dict` skip-tokens and all `cursor`-based pagination → unaffected.

## Tests

New `TestSkipTokenValidation` covers sync + async reject/accept paths and asserts `query` is never called on rejection. Full suite: 314 passed; ruff + mypy clean.

Consumed by downstream pathfinder issue (harden get_all_async). Ships as 0.8.2.